### PR TITLE
feat(cosh-ng): [gateway] add ACP entrypoint

### DIFF
--- a/docs/user-guide/en/user-entrypoint/cosh-ng/README.md
+++ b/docs/user-guide/en/user-entrypoint/cosh-ng/README.md
@@ -42,6 +42,11 @@ Use read-only commands first. Add `--dry-run` to a supported package or service 
 
 ## Integrate and automate
 
+- Run `cosh agent doctor --profile codex --workspace "$PWD"` to verify a
+  separately installed `codex-acp`, or select `claude-code` for
+  `claude-agent-acp`. Run one turn by piping a bounded UTF-8 prompt into
+  `cosh agent run`; add `--output jsonl` for stable streamed events. COSH does
+  not run `npx`, download packages, or accept arbitrary adapter commands.
 - [Structured OS CLI](cli/overview.md) — command domains and safe automation patterns.
 - [Output format](output-format.md) — the `CoshResponse<T>` success and error envelope.
 - [Headless mode](core/headless-mode.md) — JSONL integration for other frontends.

--- a/docs/user-guide/zh/user-entrypoint/cosh-ng/README.md
+++ b/docs/user-guide/zh/user-entrypoint/cosh-ng/README.md
@@ -42,6 +42,10 @@ cosh-ng 是一个 AI 原生 Linux 终端，让日常 Shell 操作和 Agent 任�
 
 ## 集成与自动化
 
+- 运行 `cosh agent doctor --profile codex --workspace "$PWD"` 检查单独安装的
+  `codex-acp`，也可以选择 `claude-code` profile 检查 `claude-agent-acp`。把有界 UTF-8
+  prompt 通过管道传给 `cosh agent run` 即可执行一轮任务；增加 `--output jsonl` 可以获得
+  稳定的流式事件。COSH 不运行 `npx`、不下载 package，也不接受任意 Adapter command。
 - [结构化 OS CLI](cli/overview.md)：命令域和安全的自动化方式。
 - [输出格式](output-format.md)：`CoshResponse<T>` 成功和失败响应封装。
 - [无界面模式](core/headless-mode.md)：供其他前端使用的 JSONL 集成。

--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -1550,6 +1550,7 @@ build_sec_core() {
 build_cosh_ng() {
     step "Building cosh-ng"
     local dir="$PROJECT_ROOT/src/cosh-ng"
+    local cosh_ng_toolchain="${COSH_NG_RUST_TOOLCHAIN:-1.88.0}"
     [[ -d "$dir" ]] || die "Directory not found: $dir"
 
     local component_root bin source
@@ -1557,8 +1558,8 @@ build_cosh_ng() {
 
     if $DRY_RUN; then
         echo "DRY-RUN: rm -rf $component_root"
-        echo "DRY-RUN: CARGO_NET_GIT_FETCH_WITH_CLI=true cargo build --manifest-path $dir/Cargo.toml --workspace --release"
-        for bin in cosh-cli cosh-core cosh-shell; do
+        echo "DRY-RUN: CARGO_NET_GIT_FETCH_WITH_CLI=true rustup run $cosh_ng_toolchain cargo build --manifest-path $dir/Cargo.toml --workspace --release"
+        for bin in cosh-cli cosh-core cosh-gateway cosh-shell; do
             echo "DRY-RUN: install $dir/target/release/$bin -> $component_root/bin/$bin"
         done
         ok "cosh-ng build plan generated"
@@ -1574,9 +1575,10 @@ build_cosh_ng() {
     run_logged_timeout "${COSH_NG_BUILD_TIMEOUT:-1200}" \
         "cargo build (cosh-ng workspace)" \
         env CARGO_NET_GIT_FETCH_WITH_CLI=true \
-        cargo build --manifest-path "$dir/Cargo.toml" --workspace --release
+        rustup run "$cosh_ng_toolchain" cargo build \
+            --manifest-path "$dir/Cargo.toml" --workspace --release
 
-    for bin in cosh-cli cosh-core cosh-shell; do
+    for bin in cosh-cli cosh-core cosh-gateway cosh-shell; do
         source="$dir/target/release/$bin"
         copy_file "$source" "$component_root/bin/$bin" 0755
     done
@@ -1892,14 +1894,14 @@ install_cosh_ng() {
     staged="$(component_target_dir cosh-ng)/bin"
 
     if $DRY_RUN; then
-        for bin in cosh-cli cosh-core cosh-shell; do
+        for bin in cosh-cli cosh-core cosh-gateway cosh-shell; do
             echo "DRY-RUN: install -p -m 0755 $staged/$bin $INSTALL_BIN_DIR/$bin"
         done
         ok "cosh-ng install plan generated for ${INSTALL_BIN_DIR}/"
         return 0
     fi
 
-    for bin in cosh-cli cosh-core cosh-shell; do
+    for bin in cosh-cli cosh-core cosh-gateway cosh-shell; do
         [[ -f "$staged/$bin" ]] || die "Built cosh-ng binary not found: $staged/$bin"
         target="$INSTALL_BIN_DIR/$bin"
         if [[ "$INSTALL_MODE" == "system" ]]; then
@@ -1911,7 +1913,7 @@ install_cosh_ng() {
         fi
     done
 
-    ok "cosh-ng installed to ${INSTALL_BIN_DIR}/{cosh-cli,cosh-core,cosh-shell}"
+    ok "cosh-ng installed to ${INSTALL_BIN_DIR}/{cosh-cli,cosh-core,cosh-gateway,cosh-shell}"
     info "Start cosh-ng with: ${INSTALL_BIN_DIR}/cosh-shell"
     info "The existing cosh launcher was not changed."
 }
@@ -2076,7 +2078,7 @@ uninstall_cosh_ng() {
     step "Uninstalling cosh-ng"
     local bin
 
-    for bin in cosh-cli cosh-core cosh-shell; do
+    for bin in cosh-cli cosh-core cosh-gateway cosh-shell; do
         if $DRY_RUN; then
             echo "DRY-RUN: rm -f $INSTALL_BIN_DIR/$bin"
         elif [[ "$INSTALL_MODE" == "system" ]]; then

--- a/src/cosh-ng/Cargo.lock
+++ b/src/cosh-ng/Cargo.lock
@@ -726,11 +726,13 @@ name = "cosh-gateway"
 version = "0.15.0"
 dependencies = [
  "agent-client-protocol",
+ "clap",
  "cosh-gateway-contracts",
  "nix 0.29.0",
  "rusqlite",
  "serde",
  "serde_json",
+ "signal-hook",
  "tempfile",
  "thiserror 2.0.18",
  "wait-timeout",

--- a/src/cosh-ng/README.md
+++ b/src/cosh-ng/README.md
@@ -64,6 +64,20 @@ the shell and Core. With the cosh-core runtime, `/agent` opens a one-shot
 Composer that accepts a leading `/skill:<name>` and validated workspace-local
 `@path` references.
 
+To run one locally installed ACP adapter without entering the interactive
+Shell, verify it first and then pipe the prompt through stdin:
+
+```bash
+cosh agent doctor --profile codex --workspace "$PWD"
+printf '%s\n' 'summarize the current changes' | \
+  cosh agent run --profile codex --workspace "$PWD"
+```
+
+The first release accepts only the built-in `codex` and `claude-code`
+profiles. Install the corresponding `codex-acp` or `claude-agent-acp`
+executable separately; COSH never invokes `npx` or downloads an adapter at
+runtime. Permission callbacks are rejected by default in this entrypoint.
+
 ## Documentation
 
 - [User guide](../../docs/user-guide/en/user-entrypoint/cosh-ng/README.md)

--- a/src/cosh-ng/README_zh.md
+++ b/src/cosh-ng/README_zh.md
@@ -61,6 +61,19 @@ $ /session status
 会打开一次性 Composer，可在开头指定 `/skill:<name>`，并添加经过验证的工作空间内
 `@路径`引用。
 
+如果要在不进入交互式 Shell 的情况下运行本机已安装的 ACP Adapter，可以先检查
+Adapter，再通过 stdin 发送 prompt。
+
+```bash
+cosh agent doctor --profile codex --workspace "$PWD"
+printf '%s\n' 'summarize the current changes' | \
+  cosh agent run --profile codex --workspace "$PWD"
+```
+
+首个版本只接受内置 `codex` 与 `claude-code` profile。对应的 `codex-acp` 或
+`claude-agent-acp` executable 需要单独安装。COSH 在 runtime 中不会调用 `npx`，也不会
+下载 Adapter。这个 entrypoint 默认拒绝 permission callback。
+
 ## 文档
 
 - [用户手册](../../docs/user-guide/zh/user-entrypoint/cosh-ng/README.md)

--- a/src/cosh-ng/cosh-ng.spec.in
+++ b/src/cosh-ng/cosh-ng.spec.in
@@ -17,7 +17,7 @@ BuildRequires:  openssl-devel
 Requires(post):   lua
 Requires(postun): lua
 Requires:       openssl-libs
-Provides:       %{_bindir}/cosh-cli %{_bindir}/cosh
+Provides:       %{_bindir}/cosh-cli %{_bindir}/cosh %{_libexecdir_cosh}/cosh-gateway
 Provides:       anolisa-component(cosh-ng)
 Conflicts:      copilot-shell
 
@@ -37,6 +37,7 @@ rm -rf %{buildroot}
 # Install internal binaries to libexec
 install -d %{buildroot}%{_libexecdir_cosh}
 install -m 0755 target/release/cosh-core %{buildroot}%{_libexecdir_cosh}/cosh-core
+install -m 0755 target/release/cosh-gateway %{buildroot}%{_libexecdir_cosh}/cosh-gateway
 install -m 0755 target/release/cosh-shell %{buildroot}%{_libexecdir_cosh}/cosh-shell
 
 # Install CLI binary
@@ -47,6 +48,10 @@ install -m 0755 target/release/cosh-cli %{buildroot}%{_bindir}/cosh-cli
 cat > %{buildroot}%{_bindir}/cosh << 'EOF'
 #!/bin/bash
 case "${1:-}" in
+  agent)
+    shift
+    exec %{_libexecdir_cosh}/cosh-gateway "$@"
+    ;;
   -c|--|--help|--version)
     exec %{_libexecdir_cosh}/cosh-shell "$@"
     ;;
@@ -95,6 +100,7 @@ install -m 0644 component.toml %{buildroot}%{_datadir}/anolisa/components/cosh-n
 %{_bindir}/cosh-switch
 %dir %{_libexecdir_cosh}
 %{_libexecdir_cosh}/cosh-core
+%{_libexecdir_cosh}/cosh-gateway
 %{_libexecdir_cosh}/cosh-shell
 %{_datadir}/anolisa/components/cosh-ng/component.toml
 

--- a/src/cosh-ng/crates/cosh-gateway/Cargo.toml
+++ b/src/cosh-ng/crates/cosh-gateway/Cargo.toml
@@ -8,11 +8,13 @@ repository.workspace = true
 
 [dependencies]
 agent-client-protocol = { workspace = true }
+clap = { workspace = true }
 cosh-gateway-contracts = { path = "../cosh-gateway-contracts" }
 nix = { workspace = true }
 rusqlite = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+signal-hook = { workspace = true }
 thiserror = { workspace = true }
 wait-timeout = { workspace = true }
 

--- a/src/cosh-ng/crates/cosh-gateway/src/bin/cosh-gateway.rs
+++ b/src/cosh-ng/crates/cosh-gateway/src/bin/cosh-gateway.rs
@@ -1,0 +1,586 @@
+#![forbid(unsafe_code)]
+//! Installed local entrypoint for the narrow ACP v1 runtime profile.
+
+use std::fs::File;
+use std::io::{self, IsTerminal, Read, Write};
+use std::path::PathBuf;
+use std::process::ExitCode;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use clap::{Args, Parser, Subcommand, ValueEnum};
+use cosh_gateway::runtime::{
+    AcpRuntimeProfileId, AcpRuntimeProfileRequest, AcpRuntimeProfileResolver, AcpSessionDriver,
+    AcpSessionDriverConfig, AcpSessionEvent, AcpSessionTerminalKind, AcpV1ClientConfig,
+    AcpV1Observation, AcpV1PermissionDecision, AcpV1PermissionOptionKind, AcpV1StopReason,
+};
+use serde_json::{json, Value};
+use thiserror::Error;
+
+const MAX_ACP_FRAME_BYTES: usize = 1024 * 1024;
+const MAX_PROMPT_BYTES: usize = 256 * 1024;
+const EVENT_POLL_INTERVAL: Duration = Duration::from_millis(100);
+const EVENT_DEADLINE: Duration = Duration::from_secs(15);
+const SHUTDOWN_DEADLINE: Duration = Duration::from_secs(5);
+
+const EXIT_INPUT: u8 = 10;
+const EXIT_PROFILE: u8 = 11;
+const EXIT_RUNTIME: u8 = 12;
+const EXIT_AGENT: u8 = 13;
+const EXIT_CANCELLED: u8 = 130;
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "cosh-gateway",
+    version,
+    about = "Run installed ACP v1 Agent adapters through COSH"
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, Subcommand)]
+enum Command {
+    /// Verify an installed adapter through initialize and session/new.
+    Doctor(ProfileArgs),
+    /// Run one text prompt read from stdin or an explicit file.
+    Run(RunArgs),
+}
+
+#[derive(Debug, Clone, Args)]
+struct ProfileArgs {
+    /// Fixed installed adapter profile.
+    #[arg(long, value_enum, default_value_t = Profile::Codex)]
+    profile: Profile,
+    /// Absolute trusted adapter path; basename must match the profile.
+    #[arg(long)]
+    adapter: Option<PathBuf>,
+    /// Existing workspace directory bound to the ACP session.
+    #[arg(long, default_value = ".")]
+    workspace: PathBuf,
+    /// Presentation format for stable COSH events and errors.
+    #[arg(long, value_enum, default_value_t = Output::Human)]
+    output: Output,
+}
+
+#[derive(Debug, Clone, Args)]
+struct RunArgs {
+    #[command(flatten)]
+    profile: ProfileArgs,
+    /// Read the prompt from this regular file; default is stdin.
+    #[arg(long, value_name = "PATH")]
+    prompt_file: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Copy, Default, ValueEnum)]
+enum Profile {
+    #[default]
+    Codex,
+    ClaudeCode,
+}
+
+impl From<Profile> for AcpRuntimeProfileId {
+    fn from(profile: Profile) -> Self {
+        match profile {
+            Profile::Codex => Self::Codex,
+            Profile::ClaudeCode => Self::ClaudeCode,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, ValueEnum)]
+enum Output {
+    #[default]
+    Human,
+    Jsonl,
+}
+
+#[derive(Debug, Error)]
+enum CliError {
+    #[error("failed to resolve installed ACP profile: {0}")]
+    Profile(String),
+    #[error("failed to read prompt: {0}")]
+    Input(#[source] io::Error),
+    #[error("prompt path is not a regular file: {0}")]
+    PromptNotRegular(PathBuf),
+    #[error("prompt is empty")]
+    EmptyPrompt,
+    #[error("prompt exceeds the {MAX_PROMPT_BYTES}-byte limit")]
+    PromptTooLarge,
+    #[error("failed to register interrupt handling: {0}")]
+    Signal(#[source] io::Error),
+    #[error("ACP runtime failed: {0}")]
+    Runtime(String),
+    #[error("ACP Agent rejected or did not complete the prompt")]
+    Agent,
+    #[error("ACP operation was cancelled")]
+    Cancelled,
+}
+
+impl CliError {
+    fn exit_code(&self) -> u8 {
+        match self {
+            Self::Input(_)
+            | Self::PromptNotRegular(_)
+            | Self::EmptyPrompt
+            | Self::PromptTooLarge => EXIT_INPUT,
+            Self::Profile(_) => EXIT_PROFILE,
+            Self::Runtime(_) | Self::Signal(_) => EXIT_RUNTIME,
+            Self::Agent => EXIT_AGENT,
+            Self::Cancelled => EXIT_CANCELLED,
+        }
+    }
+
+    fn code(&self) -> &'static str {
+        match self {
+            Self::Input(_) => "prompt_read_failed",
+            Self::PromptNotRegular(_) => "prompt_not_regular",
+            Self::EmptyPrompt => "prompt_empty",
+            Self::PromptTooLarge => "prompt_too_large",
+            Self::Profile(_) => "profile_invalid",
+            Self::Signal(_) => "signal_handler_failed",
+            Self::Runtime(_) => "runtime_failed",
+            Self::Agent => "agent_incomplete",
+            Self::Cancelled => "cancelled",
+        }
+    }
+}
+
+struct Reporter {
+    output: Output,
+}
+
+impl Reporter {
+    fn event(&self, event: &str, fields: Value) -> Result<(), CliError> {
+        match self.output {
+            Output::Jsonl => {
+                let mut value = json!({"event": event});
+                if let (Some(target), Some(source)) = (value.as_object_mut(), fields.as_object()) {
+                    target.extend(source.clone());
+                }
+                println!("{value}");
+            }
+            Output::Human => self.human_event(event, &fields),
+        }
+        io::stdout()
+            .flush()
+            .map_err(|error| CliError::Runtime(error.to_string()))
+    }
+
+    fn human_event(&self, event: &str, fields: &Value) {
+        match event {
+            "initialized" => eprintln!("ACP v1 initialized"),
+            "session_opened" => eprintln!("ACP session opened"),
+            "session_update" => {
+                if let Some(text) = fields.get("text").and_then(Value::as_str) {
+                    print!("{}", terminal_safe(text));
+                }
+            }
+            "permission_rejected" => eprintln!("ACP permission request rejected by default"),
+            "prompt_finished" => eprintln!("\nACP prompt finished"),
+            "doctor_ok" => println!("ACP adapter is ready"),
+            "terminal" => {}
+            _ => {}
+        }
+    }
+
+    fn error(&self, error: &CliError) {
+        match self.output {
+            Output::Human => eprintln!("Error [{}]: {error}", error.code()),
+            Output::Jsonl => println!(
+                "{}",
+                json!({"event":"error", "code":error.code(), "message":error.to_string()})
+            ),
+        }
+    }
+}
+
+fn main() -> ExitCode {
+    let cli = Cli::parse();
+    let output = match &cli.command {
+        Command::Doctor(args) => args.output,
+        Command::Run(args) => args.profile.output,
+    };
+    let reporter = Reporter { output };
+    let result = match cli.command {
+        Command::Doctor(args) => doctor(args, &reporter),
+        Command::Run(args) => run(args, &reporter),
+    };
+    match result {
+        Ok(code) => ExitCode::from(code),
+        Err(error) => {
+            reporter.error(&error);
+            ExitCode::from(error.exit_code())
+        }
+    }
+}
+
+fn doctor(args: ProfileArgs, reporter: &Reporter) -> Result<u8, CliError> {
+    let interrupted = install_interrupt_handler()?;
+    let driver = launch_driver(&args)?;
+    initialize_session(&driver, reporter, &interrupted)?;
+    driver
+        .shutdown()
+        .map_err(|error| CliError::Runtime(error.to_string()))?;
+    wait_for_terminal(&driver, reporter, &interrupted)?;
+    reporter.event("doctor_ok", json!({"profile": profile_name(args.profile)}))?;
+    Ok(0)
+}
+
+fn run(args: RunArgs, reporter: &Reporter) -> Result<u8, CliError> {
+    let prompt = read_prompt(args.prompt_file.as_ref())?;
+    let interrupted = install_interrupt_handler()?;
+    let driver = launch_driver(&args.profile)?;
+    initialize_session(&driver, reporter, &interrupted)?;
+    driver
+        .prompt(prompt)
+        .map_err(|error| CliError::Runtime(error.to_string()))?;
+
+    let mut cancel_sent = false;
+    loop {
+        if interrupted.load(Ordering::Relaxed) && !cancel_sent {
+            driver
+                .control()
+                .cancel()
+                .map_err(|error| CliError::Runtime(error.to_string()))?;
+            cancel_sent = true;
+        }
+        match driver.receive_timeout(EVENT_POLL_INTERVAL) {
+            Ok(AcpSessionEvent::Observation(observation)) => {
+                if let Some(exit) = handle_observation(&driver, reporter, observation)? {
+                    driver
+                        .shutdown()
+                        .map_err(|error| CliError::Runtime(error.to_string()))?;
+                    wait_for_terminal(&driver, reporter, &interrupted)?;
+                    return Ok(exit);
+                }
+            }
+            Ok(AcpSessionEvent::Terminal(terminal)) => {
+                report_terminal(reporter, &terminal)?;
+                return terminal_exit(terminal.kind).map(Ok)?;
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                return Err(CliError::Runtime("ACP event channel closed".into()));
+            }
+        }
+    }
+}
+
+fn launch_driver(args: &ProfileArgs) -> Result<AcpSessionDriver, CliError> {
+    let request = AcpRuntimeProfileRequest::from_current_environment(
+        args.profile.into(),
+        args.adapter.clone(),
+        &args.workspace,
+    );
+    let resolved = AcpRuntimeProfileResolver::resolve(request)
+        .map_err(|error| CliError::Profile(error.to_string()))?;
+    let config = AcpSessionDriverConfig::new(
+        resolved.launch_spec(),
+        AcpV1ClientConfig::new(
+            "cosh-gateway",
+            env!("CARGO_PKG_VERSION"),
+            MAX_ACP_FRAME_BYTES,
+        ),
+        resolved.workspace(),
+    );
+    AcpSessionDriver::launch(config).map_err(|error| CliError::Runtime(error.to_string()))
+}
+
+fn initialize_session(
+    driver: &AcpSessionDriver,
+    reporter: &Reporter,
+    interrupted: &AtomicBool,
+) -> Result<(), CliError> {
+    check_interrupted(driver, interrupted)?;
+    driver
+        .initialize()
+        .map_err(|error| CliError::Runtime(error.to_string()))?;
+    wait_for_observation(driver, reporter, interrupted, |observation| {
+        matches!(observation, AcpV1Observation::Initialized { .. })
+    })?;
+    check_interrupted(driver, interrupted)?;
+    driver
+        .open_session()
+        .map_err(|error| CliError::Runtime(error.to_string()))?;
+    wait_for_observation(driver, reporter, interrupted, |observation| {
+        matches!(observation, AcpV1Observation::SessionOpened { .. })
+    })
+}
+
+fn wait_for_observation(
+    driver: &AcpSessionDriver,
+    reporter: &Reporter,
+    interrupted: &AtomicBool,
+    expected: impl Fn(&AcpV1Observation) -> bool,
+) -> Result<(), CliError> {
+    let deadline = std::time::Instant::now() + EVENT_DEADLINE;
+    loop {
+        check_interrupted(driver, interrupted)?;
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        if remaining.is_zero() {
+            return Err(CliError::Runtime(
+                "ACP event delivery deadline exceeded".into(),
+            ));
+        }
+        match driver.receive_timeout(remaining.min(EVENT_POLL_INTERVAL)) {
+            Ok(AcpSessionEvent::Observation(observation)) => {
+                let matched = expected(&observation);
+                handle_observation(driver, reporter, observation)?;
+                if matched {
+                    return Ok(());
+                }
+            }
+            Ok(AcpSessionEvent::Terminal(terminal)) => {
+                report_terminal(reporter, &terminal)?;
+                return terminal_exit(terminal.kind).map(|_| ());
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                return Err(CliError::Runtime("ACP event channel closed".into()));
+            }
+        }
+    }
+}
+
+fn handle_observation(
+    driver: &AcpSessionDriver,
+    reporter: &Reporter,
+    observation: AcpV1Observation,
+) -> Result<Option<u8>, CliError> {
+    match observation {
+        AcpV1Observation::Initialized { agent_info, .. } => {
+            reporter.event(
+                "initialized",
+                json!({"agent": agent_info.map(|info| json!({
+                    "name": info.name, "version": info.version
+                }))}),
+            )?;
+        }
+        AcpV1Observation::SessionOpened { session_id } => {
+            reporter.event("session_opened", json!({"session_id":session_id}))?;
+        }
+        AcpV1Observation::SessionUpdate { session_id, update } => {
+            let text = update
+                .get("content")
+                .and_then(|content| content.get("text"))
+                .and_then(Value::as_str);
+            if let Some(text) = text {
+                reporter.event(
+                    "session_update",
+                    json!({"session_id":session_id, "text":text}),
+                )?;
+            } else {
+                reporter.event(
+                    "session_diagnostic",
+                    json!({"session_id":session_id, "kind":"non_text_update"}),
+                )?;
+            }
+        }
+        AcpV1Observation::PermissionRequested(request) => {
+            let options = request
+                .options
+                .iter()
+                .filter_map(|option| match option.kind {
+                    AcpV1PermissionOptionKind::AllowOnce => Some("allow_once"),
+                    AcpV1PermissionOptionKind::RejectOnce => Some("reject_once"),
+                    _ => None,
+                })
+                .collect::<Vec<_>>();
+            reporter.event(
+                "permission_rejected",
+                json!({"request_id":request.request_id.to_string(), "options":options}),
+            )?;
+            driver
+                .answer_permission(request.request_id, AcpV1PermissionDecision::Cancelled)
+                .map_err(|error| CliError::Runtime(error.to_string()))?;
+        }
+        AcpV1Observation::PromptFinished {
+            session_id,
+            stop_reason,
+        } => {
+            reporter.event(
+                "prompt_finished",
+                json!({"session_id":session_id, "stop_reason":stop_reason_name(stop_reason)}),
+            )?;
+            return Ok(Some(if stop_reason == AcpV1StopReason::EndTurn {
+                0
+            } else {
+                EXIT_AGENT
+            }));
+        }
+        AcpV1Observation::RequestFailed {
+            request,
+            code,
+            message,
+        } => {
+            reporter.event(
+                "request_failed",
+                json!({"request":format!("{request:?}"), "code":code, "message":message}),
+            )?;
+            return Err(CliError::Agent);
+        }
+        AcpV1Observation::UnsupportedClientRequest { request_id, method } => {
+            reporter.event(
+                "unsupported_request",
+                json!({"request_id":request_id.to_string(), "method":method}),
+            )?;
+        }
+        AcpV1Observation::UnsupportedNotification { method } => {
+            reporter.event("unsupported_notification", json!({"method":method}))?;
+        }
+        AcpV1Observation::TransportClosed => {
+            return Err(CliError::Runtime("ACP transport closed".into()));
+        }
+    }
+    Ok(None)
+}
+
+fn wait_for_terminal(
+    driver: &AcpSessionDriver,
+    reporter: &Reporter,
+    interrupted: &AtomicBool,
+) -> Result<(), CliError> {
+    let deadline = std::time::Instant::now() + SHUTDOWN_DEADLINE;
+    loop {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        if remaining.is_zero() {
+            return Err(CliError::Runtime(
+                "ACP shutdown event deadline exceeded".into(),
+            ));
+        }
+        match driver.receive_timeout(remaining.min(EVENT_POLL_INTERVAL)) {
+            Ok(AcpSessionEvent::Observation(observation)) => {
+                handle_observation(driver, reporter, observation)?;
+            }
+            Ok(AcpSessionEvent::Terminal(terminal)) => {
+                report_terminal(reporter, &terminal)?;
+                return terminal_exit(terminal.kind).map(|_| ());
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                if interrupted.load(Ordering::Relaxed) {
+                    let _ = driver.control().cancel();
+                }
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                return Err(CliError::Runtime("ACP terminal channel closed".into()));
+            }
+        }
+    }
+}
+
+fn report_terminal(
+    reporter: &Reporter,
+    terminal: &cosh_gateway::runtime::AcpSessionTerminal,
+) -> Result<(), CliError> {
+    reporter.event(
+        "terminal",
+        json!({
+            "kind":format!("{:?}", terminal.kind).to_ascii_lowercase(),
+            "detail":terminal.detail,
+        }),
+    )
+}
+
+fn terminal_exit(kind: AcpSessionTerminalKind) -> Result<u8, CliError> {
+    match kind {
+        AcpSessionTerminalKind::Shutdown => Ok(0),
+        AcpSessionTerminalKind::Cancelled => Err(CliError::Cancelled),
+        AcpSessionTerminalKind::Failed => Err(CliError::Runtime("ACP session failed".into())),
+    }
+}
+
+fn check_interrupted(driver: &AcpSessionDriver, interrupted: &AtomicBool) -> Result<(), CliError> {
+    if interrupted.load(Ordering::Relaxed) {
+        let _ = driver.control().cancel();
+        Err(CliError::Cancelled)
+    } else {
+        Ok(())
+    }
+}
+
+fn install_interrupt_handler() -> Result<Arc<AtomicBool>, CliError> {
+    let interrupted = Arc::new(AtomicBool::new(false));
+    signal_hook::flag::register(signal_hook::consts::SIGINT, Arc::clone(&interrupted))
+        .map_err(CliError::Signal)?;
+    Ok(interrupted)
+}
+
+fn read_prompt(path: Option<&PathBuf>) -> Result<String, CliError> {
+    let mut input: Box<dyn Read> = match path {
+        Some(path) => {
+            let file = File::open(path).map_err(CliError::Input)?;
+            if !file.metadata().map_err(CliError::Input)?.is_file() {
+                return Err(CliError::PromptNotRegular(path.clone()));
+            }
+            Box::new(file)
+        }
+        None => {
+            if io::stdin().is_terminal() {
+                eprintln!("Enter prompt, then press Ctrl-D:");
+            }
+            Box::new(io::stdin())
+        }
+    };
+    let mut bytes = Vec::new();
+    input
+        .by_ref()
+        .take((MAX_PROMPT_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)
+        .map_err(CliError::Input)?;
+    if bytes.len() > MAX_PROMPT_BYTES {
+        return Err(CliError::PromptTooLarge);
+    }
+    let prompt = String::from_utf8(bytes)
+        .map_err(|error| CliError::Input(io::Error::new(io::ErrorKind::InvalidData, error)))?;
+    if prompt.trim().is_empty() {
+        return Err(CliError::EmptyPrompt);
+    }
+    Ok(prompt)
+}
+
+fn terminal_safe(value: &str) -> String {
+    value
+        .chars()
+        .flat_map(|character| match character {
+            '\n' | '\t' => vec![character],
+            character if character.is_control() => character.escape_default().collect(),
+            character => vec![character],
+        })
+        .collect()
+}
+
+fn profile_name(profile: Profile) -> &'static str {
+    match profile {
+        Profile::Codex => "codex",
+        Profile::ClaudeCode => "claude-code",
+    }
+}
+
+fn stop_reason_name(reason: AcpV1StopReason) -> &'static str {
+    match reason {
+        AcpV1StopReason::EndTurn => "end_turn",
+        AcpV1StopReason::MaxTokens => "max_tokens",
+        AcpV1StopReason::MaxTurnRequests => "max_turn_requests",
+        AcpV1StopReason::Refusal => "refusal",
+        AcpV1StopReason::Cancelled => "cancelled",
+        AcpV1StopReason::Unsupported => "unsupported",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn terminal_text_escapes_control_sequences() {
+        assert_eq!(terminal_safe("ok\u{1b}[2J\rnext"), "ok\\u{1b}[2J\\rnext");
+    }
+
+    #[test]
+    fn cli_does_not_accept_prompt_as_an_argument() {
+        assert!(Cli::try_parse_from(["cosh-gateway", "run", "secret prompt"]).is_err());
+    }
+}

--- a/src/cosh-ng/crates/cosh-gateway/src/runtime/profile.rs
+++ b/src/cosh-ng/crates/cosh-gateway/src/runtime/profile.rs
@@ -200,6 +200,16 @@ impl ResolvedAcpRuntimeProfile {
         self.environment.keys().map(OsString::as_os_str)
     }
 
+    /// Builds a fresh supervised launch specification for this pinned profile.
+    #[must_use]
+    pub fn launch_spec(&self) -> RuntimeLaunchSpec {
+        let profile = self.profile.profile();
+        let mut spec = RuntimeLaunchSpec::new(&self.executable, &self.workspace);
+        spec.arguments = profile.arguments.iter().map(OsString::from).collect();
+        spec.environment.clone_from(&self.environment);
+        spec
+    }
+
     /// Launches the pinned adapter with the ACP v1 runtime bridge.
     ///
     /// # Errors
@@ -209,11 +219,7 @@ impl ResolvedAcpRuntimeProfile {
         &self,
         client: AcpV1ClientConfig,
     ) -> Result<AcpV1RuntimeBridge, AcpRuntimeProfileLaunchError> {
-        let profile = self.profile.profile();
-        let mut spec = RuntimeLaunchSpec::new(&self.executable, &self.workspace);
-        spec.arguments = profile.arguments.iter().map(OsString::from).collect();
-        spec.environment.clone_from(&self.environment);
-        AcpV1RuntimeBridge::launch(&spec, client).map_err(Into::into)
+        AcpV1RuntimeBridge::launch(&self.launch_spec(), client).map_err(Into::into)
     }
 }
 

--- a/src/cosh-ng/crates/cosh-gateway/tests/cli_entrypoint.rs
+++ b/src/cosh-ng/crates/cosh-gateway/tests/cli_entrypoint.rs
@@ -1,0 +1,132 @@
+//! Installed ACP entrypoint behavior over a deterministic local fake adapter.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::io::Write;
+use std::os::unix::fs::PermissionsExt;
+use std::process::{Command, Stdio};
+
+fn fake_adapter(directory: &tempfile::TempDir) -> std::path::PathBuf {
+    let path = directory.path().join("codex-acp");
+    fs::write(
+        &path,
+        r#"#!/bin/sh
+step=0
+while IFS= read -r line; do
+    step=$((step + 1))
+    case "$step" in
+        1)
+            printf '%s\n' '{"jsonrpc":"2.0","id":"cosh-acp-1","result":{"protocolVersion":1,"agentCapabilities":{},"agentInfo":{"name":"entrypoint-fake","version":"1.0"}}}'
+            ;;
+        2)
+            printf '%s\n' '{"jsonrpc":"2.0","id":"cosh-acp-2","result":{"sessionId":"entrypoint-session"}}'
+            ;;
+        3)
+            printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"entrypoint-session","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"safe\u001b[2Jtext"}}}}'
+            printf '%s\n' '{"jsonrpc":"2.0","id":"cosh-acp-3","result":{"stopReason":"end_turn"}}'
+            ;;
+    esac
+done
+"#,
+    )
+    .unwrap();
+    let mut permissions = fs::metadata(&path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&path, permissions).unwrap();
+    path
+}
+
+#[test]
+fn doctor_initializes_installed_adapter_without_prompting() {
+    let workspace = tempfile::tempdir().unwrap();
+    let adapter = fake_adapter(&workspace);
+    let output = Command::new(env!("CARGO_BIN_EXE_cosh-gateway"))
+        .args([
+            "doctor",
+            "--adapter",
+            adapter.to_str().unwrap(),
+            "--workspace",
+            workspace.path().to_str().unwrap(),
+            "--output",
+            "jsonl",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout
+        .lines()
+        .any(|line| line.contains("\"event\":\"initialized\"")));
+    assert!(stdout
+        .lines()
+        .any(|line| line.contains("\"event\":\"session_opened\"")));
+    assert!(stdout
+        .lines()
+        .any(|line| line.contains("\"event\":\"doctor_ok\"")));
+    assert!(!stdout.contains("session_update"));
+}
+
+#[test]
+fn run_reads_prompt_from_stdin_and_escapes_terminal_controls() {
+    let workspace = tempfile::tempdir().unwrap();
+    let adapter = fake_adapter(&workspace);
+    let mut child = Command::new(env!("CARGO_BIN_EXE_cosh-gateway"))
+        .args([
+            "run",
+            "--adapter",
+            adapter.to_str().unwrap(),
+            "--workspace",
+            workspace.path().to_str().unwrap(),
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(b"inspect safely\n")
+        .unwrap();
+    let output = child.wait_with_output().unwrap();
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("safe\\u{1b}[2Jtext"));
+    assert!(!stdout.as_bytes().contains(&0x1b));
+    assert!(!stdout.contains("sessionUpdate"));
+}
+
+#[test]
+fn missing_adapter_has_stable_profile_exit_and_jsonl_error() {
+    let workspace = tempfile::tempdir().unwrap();
+    let adapter = workspace.path().join("codex-acp");
+    let output = Command::new(env!("CARGO_BIN_EXE_cosh-gateway"))
+        .args([
+            "doctor",
+            "--adapter",
+            adapter.to_str().unwrap(),
+            "--workspace",
+            workspace.path().to_str().unwrap(),
+            "--output",
+            "jsonl",
+        ])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(11));
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("\"event\":\"error\""));
+    assert!(stdout.contains("\"code\":\"profile_invalid\""));
+}

--- a/src/cosh-ng/packaging/raw/assets/bin/cosh
+++ b/src/cosh-ng/packaging/raw/assets/bin/cosh
@@ -39,9 +39,14 @@ for runtime_dir in \
     "/usr/libexec/anolisa/cosh-ng"; do
     if [ -n "$runtime_dir" ] && \
         [ -x "$runtime_dir/cosh-shell" ] && \
-        [ -x "$runtime_dir/cosh-core" ]; then
+        [ -x "$runtime_dir/cosh-core" ] && \
+        [ -x "$runtime_dir/cosh-gateway" ]; then
         export PATH="$runtime_dir:$PATH"
         case "${1:-}" in
+            agent)
+                shift
+                exec "$runtime_dir/cosh-gateway" "$@"
+                ;;
             -c | -- | --help | --version)
                 exec "$runtime_dir/cosh-shell" "$@"
                 ;;

--- a/src/cosh-ng/packaging/raw/package.sh
+++ b/src/cosh-ng/packaging/raw/package.sh
@@ -82,6 +82,7 @@ normalize_modes() {
         "$stage/bin/cosh" \
         "$stage/bin/cosh-switch" \
         "$stage/libexec/anolisa/cosh-ng/cosh-core" \
+        "$stage/libexec/anolisa/cosh-ng/cosh-gateway" \
         "$stage/libexec/anolisa/cosh-ng/cosh-shell"
 }
 
@@ -99,7 +100,8 @@ stage_payload() {
         "$stage/share/doc/cosh-ng"
     install -p -m 0644 "$CONTRACT" "$stage/.anolisa/component.toml"
     install -p -m 0755 "$BIN_DIR/cosh-cli" "$stage/bin/cosh-cli"
-    install -p -m 0755 "$BIN_DIR/cosh-core" "$BIN_DIR/cosh-shell" \
+    install -p -m 0755 "$BIN_DIR/cosh-core" "$BIN_DIR/cosh-gateway" \
+        "$BIN_DIR/cosh-shell" \
         "$stage/libexec/anolisa/cosh-ng/"
     install -p -m 0755 \
         "$SCRIPT_DIR/assets/bin/cosh" \
@@ -146,7 +148,7 @@ for input in \
     "$SCRIPT_DIR/assets/bin/cosh-switch"; do
     require_file "$input"
 done
-for binary in cosh-cli cosh-core cosh-shell; do
+for binary in cosh-cli cosh-core cosh-gateway cosh-shell; do
     [ -x "$BIN_DIR/$binary" ] || die "missing executable: $BIN_DIR/$binary"
 done
 
@@ -166,14 +168,16 @@ if [ -f "$BUILD_METADATA" ]; then
         --arch "$TARGET_ARCH" \
         --metadata "$BUILD_METADATA" \
         --component-version "$VERSION" \
-        "$BIN_DIR/cosh-cli" "$BIN_DIR/cosh-core" "$BIN_DIR/cosh-shell"
+        "$BIN_DIR/cosh-cli" "$BIN_DIR/cosh-core" "$BIN_DIR/cosh-gateway" \
+        "$BIN_DIR/cosh-shell"
 elif [ "$(detect_os)-$(detect_arch)" != "$TARGET_OS-$TARGET_ARCH" ]; then
     die "cross-target packaging requires build metadata: $BUILD_METADATA"
 else
     python3 "$SCRIPT_DIR/verify-binaries.py" \
         --os "$TARGET_OS" \
         --arch "$TARGET_ARCH" \
-        "$BIN_DIR/cosh-cli" "$BIN_DIR/cosh-core" "$BIN_DIR/cosh-shell"
+        "$BIN_DIR/cosh-cli" "$BIN_DIR/cosh-core" "$BIN_DIR/cosh-gateway" \
+        "$BIN_DIR/cosh-shell"
 fi
 verify_native_binary_version
 

--- a/src/cosh-ng/tests/test-package-raw.sh
+++ b/src/cosh-ng/tests/test-package-raw.sh
@@ -43,7 +43,7 @@ if os_name == "linux":
 else:
     cpu = {"aarch64": 0x0100000C}[arch]
     content = struct.pack("<IiiIIIII", 0xFEEDFACF, cpu, 0, 2, 0, 0, 0, 0)
-for name in ("cosh-cli", "cosh-core", "cosh-shell"):
+for name in ("cosh-cli", "cosh-core", "cosh-gateway", "cosh-shell"):
     (pathlib.Path(destination) / name).write_bytes(content)
 digest = hashlib.sha256(content).hexdigest()
 metadata = [
@@ -54,7 +54,8 @@ metadata = [
     "[binaries]",
 ]
 metadata.extend(
-    f'{name} = "{digest}"' for name in ("cosh-cli", "cosh-core", "cosh-shell")
+    f'{name} = "{digest}"'
+    for name in ("cosh-cli", "cosh-core", "cosh-gateway", "cosh-shell")
 )
 (pathlib.Path(destination) / "cosh-ng-build.toml").write_text(
     "\n".join(metadata) + "\n",
@@ -64,6 +65,7 @@ PY
     chmod 0755 \
         "$destination/cosh-cli" \
         "$destination/cosh-core" \
+        "$destination/cosh-gateway" \
         "$destination/cosh-shell"
 }
 
@@ -131,6 +133,7 @@ if python3 "$ROOT/packaging/raw/verify-binaries.py" \
     --component-version "$VERSION" \
     "$LINUX_ARM64/cosh-cli" \
     "$LINUX_ARM64/cosh-core" \
+    "$LINUX_ARM64/cosh-gateway" \
     "$LINUX_ARM64/cosh-shell" >/dev/null 2>&1; then
     echo "ERROR: unexpected build metadata entry was accepted" >&2
     exit 1
@@ -158,7 +161,7 @@ test_native_without_metadata() {
         "$ROOT/.anolisa/component.toml" > "$native_source/.anolisa/component.toml"
     install -p -m 0644 "$ROOT/LICENSE" "$native_source/LICENSE"
     install -p -m 0644 "$ROOT/README.md" "$native_source/README.md"
-    for binary in cosh-cli cosh-core cosh-shell; do
+    for binary in cosh-cli cosh-core cosh-gateway cosh-shell; do
         install -p -m 0755 "$python_bin" "$native_bins/$binary"
     done
 
@@ -223,10 +226,11 @@ fi
 
 EXTRACTED="$TMP/extracted"
 install -d -m 0755 "$EXTRACTED"
-tar -xzf "$OUT_ONE/$X64_ARTIFACT" -C "$EXTRACTED"
+tar --same-permissions -xzf "$OUT_ONE/$X64_ARTIFACT" -C "$EXTRACTED"
 cmp "$LINUX_CONTRACT" "$EXTRACTED/.anolisa/component.toml"
 cmp "$LINUX_X64/cosh-cli" "$EXTRACTED/bin/cosh-cli"
 cmp "$LINUX_X64/cosh-core" "$EXTRACTED/libexec/anolisa/cosh-ng/cosh-core"
+cmp "$LINUX_X64/cosh-gateway" "$EXTRACTED/libexec/anolisa/cosh-ng/cosh-gateway"
 cmp "$LINUX_X64/cosh-shell" "$EXTRACTED/libexec/anolisa/cosh-ng/cosh-shell"
 cmp "$ROOT/LICENSE" "$EXTRACTED/share/doc/cosh-ng/LICENSE"
 cmp "$ROOT/README.md" "$EXTRACTED/share/doc/cosh-ng/README.md"
@@ -235,6 +239,7 @@ file_mode() {
     stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1"
 }
 test "$(file_mode "$EXTRACTED/bin/cosh")" = 755
+test "$(file_mode "$EXTRACTED/libexec/anolisa/cosh-ng/cosh-gateway")" = 755
 test "$(file_mode "$EXTRACTED/libexec/anolisa/cosh-ng/cosh-shell")" = 755
 test "$(file_mode "$EXTRACTED/share/doc/cosh-ng/README.md")" = 644
 test ! -e "$EXTRACTED/share/anolisa/hooks"
@@ -245,7 +250,14 @@ cat > "$EXTRACTED/libexec/anolisa/cosh-ng/cosh-shell" <<'EOF'
 printf '%s\n' "$#" "$@"
 EOF
 chmod 0755 "$EXTRACTED/libexec/anolisa/cosh-ng/cosh-shell"
+cat > "$EXTRACTED/libexec/anolisa/cosh-ng/cosh-gateway" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$#" "$@"
+EOF
+chmod 0755 "$EXTRACTED/libexec/anolisa/cosh-ng/cosh-gateway"
 test "$("$EXTRACTED/bin/cosh" --version)" = $'1\n--version'
+test "$("$EXTRACTED/bin/cosh" agent doctor --profile codex)" = \
+    $'3\ndoctor\n--profile\ncodex'
 READLINK_STUB="$TMP/readlink-without-f"
 install -d -m 0755 "$READLINK_STUB"
 install -p -m 0755 /bin/false "$READLINK_STUB/readlink"


### PR DESCRIPTION
## Why

Expose the Phase 1 ACP runtime through an installed COSH command without
requiring users to invoke internal binaries.

## What changed

- Add `cosh agent doctor` and `cosh agent run` with fixed profiles.
- Bound prompt input and sanitize human and JSONL output.
- Package `cosh-gateway` and use Rust 1.88.0 for component builds.

## Related issue

no-issue: Phase 1 implementation from the audited ACP plan

## User / Agent impact

Users can invoke installed Codex or Claude ACP adapters through `cosh agent`.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed

The new path is additive. Prompts are accepted only from stdin or bounded regular
files, and missing adapters fail closed with stable exit codes.

## Validation

- `cargo +1.88.0 test --locked --package cosh-gateway --test cli_entrypoint --bin cosh-gateway`
- scoped Clippy with `-D warnings`
- `bash src/cosh-ng/tests/test-package-raw.sh`
- clean detached-worktree validation of this commit
- documentation lint and link checks

## Documentation and rollback

Updated the bilingual component and user-entrypoint guides. Roll back this single
commit to remove the installed gateway route.