### PR TITLE
feat(cosh-ng): [gateway] audit ACP permission

### DIFF
--- a/docs/user-guide/en/user-entrypoint/cosh-ng/README.md
+++ b/docs/user-guide/en/user-entrypoint/cosh-ng/README.md
@@ -47,6 +47,16 @@ Use read-only commands first. Add `--dry-run` to a supported package or service 
   `claude-agent-acp`. Run one turn by piping a bounded UTF-8 prompt into
   `cosh agent run`; add `--output jsonl` for stable streamed events. COSH does
   not run `npx`, download packages, or accept arbitrary adapter commands.
+  Permission requests use `/dev/tty`, leaving stdin dedicated to the prompt.
+  The default `--permission prompt` offers only `allow_once` and `reject_once`;
+  no TTY, unsupported choices, EOF, and `--permission deny` all cancel without
+  authorization. Redacted append-only evidence defaults to
+  `$XDG_STATE_HOME/cosh/gateway/permission-evidence.jsonl`, falling back to
+  `$HOME/.local/state/cosh/gateway/permission-evidence.jsonl`. Use an absolute
+  `--permission-evidence PATH` to override it. COSH stores hashes and the
+  decision class, never raw prompts, tool arguments, option labels, session
+  identifiers, or workspace paths. Evidence persistence failure cancels the
+  callback and fails the run.
 - [Structured OS CLI](cli/overview.md) — command domains and safe automation patterns.
 - [Output format](output-format.md) — the `CoshResponse<T>` success and error envelope.
 - [Headless mode](core/headless-mode.md) — JSONL integration for other frontends.

--- a/docs/user-guide/zh/user-entrypoint/cosh-ng/README.md
+++ b/docs/user-guide/zh/user-entrypoint/cosh-ng/README.md
@@ -46,6 +46,15 @@ cosh-ng 是一个 AI 原生 Linux 终端，让日常 Shell 操作和 Agent 任�
   `codex-acp`，也可以选择 `claude-code` profile 检查 `claude-agent-acp`。把有界 UTF-8
   prompt 通过管道传给 `cosh agent run` 即可执行一轮任务；增加 `--output jsonl` 可以获得
   稳定的流式事件。COSH 不运行 `npx`、不下载 package，也不接受任意 Adapter command。
+  Permission request 使用 `/dev/tty`，stdin 只传递 prompt。默认的
+  `--permission prompt` 只提供 `allow_once` 与 `reject_once`；没有 TTY、只有不支持的
+  choice、遇到 EOF 或使用 `--permission deny` 时都取消且不授权。脱敏 append-only
+  evidence 默认写入 `$XDG_STATE_HOME/cosh/gateway/permission-evidence.jsonl`，没有设置
+  `XDG_STATE_HOME` 时使用
+  `$HOME/.local/state/cosh/gateway/permission-evidence.jsonl`。可以用绝对路径
+  `--permission-evidence PATH` 覆盖。COSH 只存储 digest 与 decision class，不保存 raw
+  prompt、tool argument、option label、session identifier 或 workspace path。Evidence
+  持久化失败时，callback 会被取消且本轮运行失败。
 - [结构化 OS CLI](cli/overview.md)：命令域和安全的自动化方式。
 - [输出格式](output-format.md)：`CoshResponse<T>` 成功和失败响应封装。
 - [无界面模式](core/headless-mode.md)：供其他前端使用的 JSONL 集成。

--- a/src/cosh-ng/Cargo.lock
+++ b/src/cosh-ng/Cargo.lock
@@ -732,6 +732,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "sha2",
  "signal-hook",
  "tempfile",
  "thiserror 2.0.18",

--- a/src/cosh-ng/README.md
+++ b/src/cosh-ng/README.md
@@ -76,7 +76,9 @@ printf '%s\n' 'summarize the current changes' | \
 The first release accepts only the built-in `codex` and `claude-code`
 profiles. Install the corresponding `codex-acp` or `claude-agent-acp`
 executable separately; COSH never invokes `npx` or downloads an adapter at
-runtime. Permission callbacks are rejected by default in this entrypoint.
+runtime. A permission callback prompts only on the local controlling terminal;
+without one, or with `--permission deny`, COSH cancels it. Once-only decisions
+are recorded as redacted evidence under the private local state directory.
 
 ## Documentation
 

--- a/src/cosh-ng/README_zh.md
+++ b/src/cosh-ng/README_zh.md
@@ -72,7 +72,9 @@ printf '%s\n' 'summarize the current changes' | \
 
 首个版本只接受内置 `codex` 与 `claude-code` profile。对应的 `codex-acp` 或
 `claude-agent-acp` executable 需要单独安装。COSH 在 runtime 中不会调用 `npx`，也不会
-下载 Adapter。这个 entrypoint 默认拒绝 permission callback。
+下载 Adapter。Permission callback 只在本地 controlling terminal 上提示；没有 TTY 或使用
+`--permission deny` 时，COSH 会取消请求。Once-only decision 会以脱敏 evidence 形式记录到
+private local state directory。
 
 ## 文档
 

--- a/src/cosh-ng/crates/cosh-gateway/Cargo.toml
+++ b/src/cosh-ng/crates/cosh-gateway/Cargo.toml
@@ -14,6 +14,7 @@ nix = { workspace = true }
 rusqlite = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+sha2 = { workspace = true }
 signal-hook = { workspace = true }
 thiserror = { workspace = true }
 wait-timeout = { workspace = true }

--- a/src/cosh-ng/crates/cosh-gateway/src/bin/cosh-gateway.rs
+++ b/src/cosh-ng/crates/cosh-gateway/src/bin/cosh-gateway.rs
@@ -2,14 +2,18 @@
 //! Installed local entrypoint for the narrow ACP v1 runtime profile.
 
 use std::fs::File;
-use std::io::{self, IsTerminal, Read, Write};
-use std::path::PathBuf;
+use std::io::{self, BufReader, IsTerminal, Read, Write};
+use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use clap::{Args, Parser, Subcommand, ValueEnum};
+use cosh_gateway::permission::{
+    CancelPermissionPresenter, FilePermissionEvidenceSink, OncePermissionProxy,
+    PermissionEvidenceContext, PermissionPresenter, TextPermissionPresenter,
+};
 use cosh_gateway::runtime::{
     AcpRuntimeProfileId, AcpRuntimeProfileRequest, AcpRuntimeProfileResolver, AcpSessionDriver,
     AcpSessionDriverConfig, AcpSessionEvent, AcpSessionTerminalKind, AcpV1ClientConfig,
@@ -72,6 +76,12 @@ struct RunArgs {
     /// Read the prompt from this regular file; default is stdin.
     #[arg(long, value_name = "PATH")]
     prompt_file: Option<PathBuf>,
+    /// Prompt on the local controlling terminal or deny every tool request.
+    #[arg(long, value_enum, default_value_t = PermissionMode::Prompt)]
+    permission: PermissionMode,
+    /// Absolute private JSONL evidence path; defaults below the user state directory.
+    #[arg(long, value_name = "PATH")]
+    permission_evidence: Option<PathBuf>,
 }
 
 #[derive(Debug, Clone, Copy, Default, ValueEnum)]
@@ -97,6 +107,15 @@ enum Output {
     Jsonl,
 }
 
+#[derive(Debug, Clone, Copy, Default, ValueEnum)]
+enum PermissionMode {
+    /// Ask on `/dev/tty`; cancel when no controlling terminal is available.
+    #[default]
+    Prompt,
+    /// Cancel every permission callback without presenting it.
+    Deny,
+}
+
 #[derive(Debug, Error)]
 enum CliError {
     #[error("failed to resolve installed ACP profile: {0}")]
@@ -111,6 +130,8 @@ enum CliError {
     PromptTooLarge,
     #[error("failed to register interrupt handling: {0}")]
     Signal(#[source] io::Error),
+    #[error("local permission handling failed: {0}")]
+    Permission(String),
     #[error("ACP runtime failed: {0}")]
     Runtime(String),
     #[error("ACP Agent rejected or did not complete the prompt")]
@@ -127,7 +148,7 @@ impl CliError {
             | Self::EmptyPrompt
             | Self::PromptTooLarge => EXIT_INPUT,
             Self::Profile(_) => EXIT_PROFILE,
-            Self::Runtime(_) | Self::Signal(_) => EXIT_RUNTIME,
+            Self::Runtime(_) | Self::Signal(_) | Self::Permission(_) => EXIT_RUNTIME,
             Self::Agent => EXIT_AGENT,
             Self::Cancelled => EXIT_CANCELLED,
         }
@@ -141,6 +162,7 @@ impl CliError {
             Self::PromptTooLarge => "prompt_too_large",
             Self::Profile(_) => "profile_invalid",
             Self::Signal(_) => "signal_handler_failed",
+            Self::Permission(_) => "permission_failed",
             Self::Runtime(_) => "runtime_failed",
             Self::Agent => "agent_incomplete",
             Self::Cancelled => "cancelled",
@@ -178,7 +200,11 @@ impl Reporter {
                     print!("{}", terminal_safe(text));
                 }
             }
-            "permission_rejected" => eprintln!("ACP permission request rejected by default"),
+            "permission_decided" => match fields.get("decision").and_then(Value::as_str) {
+                Some("allow_once") => eprintln!("ACP permission allowed once"),
+                Some("reject_once") => eprintln!("ACP permission rejected once"),
+                _ => eprintln!("ACP permission request cancelled"),
+            },
             "prompt_finished" => eprintln!("\nACP prompt finished"),
             "doctor_ok" => println!("ACP adapter is ready"),
             "terminal" => {}
@@ -219,7 +245,7 @@ fn main() -> ExitCode {
 
 fn doctor(args: ProfileArgs, reporter: &Reporter) -> Result<u8, CliError> {
     let interrupted = install_interrupt_handler()?;
-    let driver = launch_driver(&args)?;
+    let (driver, _) = launch_driver(&args)?;
     initialize_session(&driver, reporter, &interrupted)?;
     driver
         .shutdown()
@@ -230,9 +256,11 @@ fn doctor(args: ProfileArgs, reporter: &Reporter) -> Result<u8, CliError> {
 }
 
 fn run(args: RunArgs, reporter: &Reporter) -> Result<u8, CliError> {
+    let evidence_path = permission_evidence_path(&args)?;
     let prompt = read_prompt(args.prompt_file.as_ref())?;
     let interrupted = install_interrupt_handler()?;
-    let driver = launch_driver(&args.profile)?;
+    let (driver, workspace) = launch_driver(&args.profile)?;
+    let mut permissions = LocalPermissionHandler::new(&args, &workspace, evidence_path);
     initialize_session(&driver, reporter, &interrupted)?;
     driver
         .prompt(prompt)
@@ -249,7 +277,9 @@ fn run(args: RunArgs, reporter: &Reporter) -> Result<u8, CliError> {
         }
         match driver.receive_timeout(EVENT_POLL_INTERVAL) {
             Ok(AcpSessionEvent::Observation(observation)) => {
-                if let Some(exit) = handle_observation(&driver, reporter, observation)? {
+                if let Some(exit) =
+                    handle_observation(&driver, reporter, observation, Some(&mut permissions))?
+                {
                     driver
                         .shutdown()
                         .map_err(|error| CliError::Runtime(error.to_string()))?;
@@ -269,7 +299,7 @@ fn run(args: RunArgs, reporter: &Reporter) -> Result<u8, CliError> {
     }
 }
 
-fn launch_driver(args: &ProfileArgs) -> Result<AcpSessionDriver, CliError> {
+fn launch_driver(args: &ProfileArgs) -> Result<(AcpSessionDriver, PathBuf), CliError> {
     let request = AcpRuntimeProfileRequest::from_current_environment(
         args.profile.into(),
         args.adapter.clone(),
@@ -277,6 +307,7 @@ fn launch_driver(args: &ProfileArgs) -> Result<AcpSessionDriver, CliError> {
     );
     let resolved = AcpRuntimeProfileResolver::resolve(request)
         .map_err(|error| CliError::Profile(error.to_string()))?;
+    let workspace = resolved.workspace().to_path_buf();
     let config = AcpSessionDriverConfig::new(
         resolved.launch_spec(),
         AcpV1ClientConfig::new(
@@ -286,7 +317,9 @@ fn launch_driver(args: &ProfileArgs) -> Result<AcpSessionDriver, CliError> {
         ),
         resolved.workspace(),
     );
-    AcpSessionDriver::launch(config).map_err(|error| CliError::Runtime(error.to_string()))
+    let driver =
+        AcpSessionDriver::launch(config).map_err(|error| CliError::Runtime(error.to_string()))?;
+    Ok((driver, workspace))
 }
 
 fn initialize_session(
@@ -328,7 +361,7 @@ fn wait_for_observation(
         match driver.receive_timeout(remaining.min(EVENT_POLL_INTERVAL)) {
             Ok(AcpSessionEvent::Observation(observation)) => {
                 let matched = expected(&observation);
-                handle_observation(driver, reporter, observation)?;
+                handle_observation(driver, reporter, observation, None)?;
                 if matched {
                     return Ok(());
                 }
@@ -349,6 +382,7 @@ fn handle_observation(
     driver: &AcpSessionDriver,
     reporter: &Reporter,
     observation: AcpV1Observation,
+    permissions: Option<&mut LocalPermissionHandler>,
 ) -> Result<Option<u8>, CliError> {
     match observation {
         AcpV1Observation::Initialized { agent_info, .. } => {
@@ -380,22 +414,22 @@ fn handle_observation(
             }
         }
         AcpV1Observation::PermissionRequested(request) => {
-            let options = request
-                .options
-                .iter()
-                .filter_map(|option| match option.kind {
-                    AcpV1PermissionOptionKind::AllowOnce => Some("allow_once"),
-                    AcpV1PermissionOptionKind::RejectOnce => Some("reject_once"),
-                    _ => None,
-                })
-                .collect::<Vec<_>>();
-            reporter.event(
-                "permission_rejected",
-                json!({"request_id":request.request_id.to_string(), "options":options}),
-            )?;
+            let request_id = request.request_id.clone();
+            let resolved = permissions
+                .ok_or_else(|| CliError::Permission("permission UI is unavailable".into()))
+                .and_then(|handler| handler.resolve(&request));
+            let (decision, decision_name) = match resolved {
+                Ok(value) => value,
+                Err(error) => {
+                    let _ =
+                        driver.answer_permission(request_id, AcpV1PermissionDecision::Cancelled);
+                    return Err(error);
+                }
+            };
             driver
-                .answer_permission(request.request_id, AcpV1PermissionDecision::Cancelled)
+                .answer_permission(request_id, decision)
                 .map_err(|error| CliError::Runtime(error.to_string()))?;
+            reporter.event("permission_decided", json!({"decision":decision_name}))?;
         }
         AcpV1Observation::PromptFinished {
             session_id,
@@ -438,6 +472,137 @@ fn handle_observation(
     Ok(None)
 }
 
+struct LocalPermissionHandler {
+    mode: PermissionMode,
+    profile: &'static str,
+    workspace: Vec<u8>,
+    evidence_path: PathBuf,
+    evidence: Option<FilePermissionEvidenceSink>,
+}
+
+impl LocalPermissionHandler {
+    fn new(args: &RunArgs, workspace: &Path, evidence_path: PathBuf) -> Self {
+        #[cfg(unix)]
+        use std::os::unix::ffi::OsStrExt;
+
+        #[cfg(unix)]
+        let workspace = workspace.as_os_str().as_bytes().to_vec();
+        #[cfg(not(unix))]
+        let workspace = workspace.to_string_lossy().as_bytes().to_vec();
+        Self {
+            mode: args.permission,
+            profile: profile_name(args.profile.profile),
+            workspace,
+            evidence_path,
+            evidence: None,
+        }
+    }
+
+    fn resolve(
+        &mut self,
+        request: &cosh_gateway::runtime::AcpV1PermissionRequest,
+    ) -> Result<(AcpV1PermissionDecision, &'static str), CliError> {
+        let occurred_at_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|_| CliError::Permission("system clock precedes the Unix epoch".into()))?
+            .as_millis()
+            .try_into()
+            .map_err(|_| CliError::Permission("system clock is out of range".into()))?;
+        let context = PermissionEvidenceContext {
+            profile: self.profile,
+            canonical_workspace: &self.workspace,
+            actor_uid: nix::unistd::Uid::effective().as_raw(),
+            occurred_at_ms,
+        };
+        if self.evidence.is_none() {
+            self.evidence = Some(
+                FilePermissionEvidenceSink::open_in_private_state(&self.evidence_path)
+                    .map_err(|error| CliError::Permission(error.to_string()))?,
+            );
+        }
+        let evidence = self
+            .evidence
+            .as_mut()
+            .ok_or_else(|| CliError::Permission("permission evidence is unavailable".into()))?;
+        let decision = match self.mode {
+            PermissionMode::Deny => {
+                resolve_permission(CancelPermissionPresenter, evidence, context, request)?
+            }
+            PermissionMode::Prompt => match local_terminal_presenter() {
+                Some(presenter) => resolve_permission(presenter, evidence, context, request)?,
+                None => resolve_permission(CancelPermissionPresenter, evidence, context, request)?,
+            },
+        };
+        let name = match &decision {
+            AcpV1PermissionDecision::Cancelled => "cancelled",
+            AcpV1PermissionDecision::Selected { option_id } => request
+                .options
+                .iter()
+                .find(|option| &option.option_id == option_id)
+                .map_or("cancelled", |option| match option.kind {
+                    AcpV1PermissionOptionKind::AllowOnce => "allow_once",
+                    AcpV1PermissionOptionKind::RejectOnce => "reject_once",
+                    _ => "cancelled",
+                }),
+        };
+        Ok((decision, name))
+    }
+}
+
+fn resolve_permission<P: PermissionPresenter>(
+    presenter: P,
+    evidence: &mut FilePermissionEvidenceSink,
+    context: PermissionEvidenceContext<'_>,
+    request: &cosh_gateway::runtime::AcpV1PermissionRequest,
+) -> Result<AcpV1PermissionDecision, CliError> {
+    let mut proxy = OncePermissionProxy::new(presenter, evidence);
+    proxy
+        .resolve(context, request)
+        .map_err(|error| CliError::Permission(error.to_string()))
+}
+
+fn local_terminal_presenter() -> Option<TextPermissionPresenter<BufReader<File>, File>> {
+    let terminal = File::options()
+        .read(true)
+        .write(true)
+        .open("/dev/tty")
+        .ok()?;
+    if !terminal.is_terminal() {
+        return None;
+    }
+    let input = terminal.try_clone().ok()?;
+    Some(TextPermissionPresenter::new(
+        BufReader::new(input),
+        terminal,
+    ))
+}
+
+fn permission_evidence_path(args: &RunArgs) -> Result<PathBuf, CliError> {
+    if let Some(path) = &args.permission_evidence {
+        return if path.is_absolute() {
+            Ok(path.clone())
+        } else {
+            Err(CliError::Permission(
+                "permission evidence path must be absolute".into(),
+            ))
+        };
+    }
+    if let Some(state) = std::env::var_os("XDG_STATE_HOME") {
+        let state = PathBuf::from(state);
+        if !state.is_absolute() {
+            return Err(CliError::Permission(
+                "XDG_STATE_HOME must be absolute".into(),
+            ));
+        }
+        return Ok(state.join("cosh/gateway/permission-evidence.jsonl"));
+    }
+    let home = std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .filter(|path| path.is_absolute())
+        .ok_or_else(|| CliError::Permission("absolute HOME is required".into()))?;
+    Ok(home.join(".local/state/cosh/gateway/permission-evidence.jsonl"))
+}
+
 fn wait_for_terminal(
     driver: &AcpSessionDriver,
     reporter: &Reporter,
@@ -453,7 +618,7 @@ fn wait_for_terminal(
         }
         match driver.receive_timeout(remaining.min(EVENT_POLL_INTERVAL)) {
             Ok(AcpSessionEvent::Observation(observation)) => {
-                handle_observation(driver, reporter, observation)?;
+                handle_observation(driver, reporter, observation, None)?;
             }
             Ok(AcpSessionEvent::Terminal(terminal)) => {
                 report_terminal(reporter, &terminal)?;

--- a/src/cosh-ng/crates/cosh-gateway/src/lib.rs
+++ b/src/cosh-ng/crates/cosh-gateway/src/lib.rs
@@ -2,6 +2,7 @@
 //! fail-closed capability admission foundations.
 
 pub mod capability;
+pub mod permission;
 pub mod runtime;
 pub mod storage;
 pub mod task;

--- a/src/cosh-ng/crates/cosh-gateway/src/permission.rs
+++ b/src/cosh-ng/crates/cosh-gateway/src/permission.rs
@@ -1,0 +1,277 @@
+//! Fail-closed local handling and redacted evidence for ACP once-only choices.
+
+mod evidence;
+
+use std::io::{self, BufRead, Write};
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::runtime::{AcpV1PermissionDecision, AcpV1PermissionOptionKind, AcpV1PermissionRequest};
+
+pub use evidence::{FilePermissionEvidenceSink, PermissionEvidenceError};
+
+const MAX_DISPLAY_BYTES: usize = 512;
+
+/// Stable local decision class. It never creates a durable trust rule.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OncePermissionDecision {
+    /// Select an Agent-provided `allow_once` option.
+    AllowOnce,
+    /// Select an Agent-provided `reject_once` option.
+    RejectOnce,
+    /// Refuse to select an option because interaction could not complete.
+    Cancelled,
+}
+
+/// Redacted interaction presented to a local actor.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OncePermissionPrompt {
+    /// Bounded untrusted display title derived from the tool call.
+    pub title: String,
+    /// Whether the Agent offered an `allow_once` option.
+    pub can_allow_once: bool,
+    /// Whether the Agent offered a `reject_once` option.
+    pub can_reject_once: bool,
+}
+
+/// Durable, redacted evidence written before replying to the Agent.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PermissionEvidence {
+    /// Evidence schema version.
+    pub schema_version: u16,
+    /// Milliseconds since the Unix epoch.
+    pub occurred_at_ms: u64,
+    /// Stable built-in profile name.
+    pub profile: String,
+    /// SHA-256 of the canonical workspace path bytes.
+    pub workspace_digest: String,
+    /// SHA-256 of the opaque ACP session identifier.
+    pub session_digest: String,
+    /// SHA-256 of the JSON-RPC request identifier.
+    pub request_digest: String,
+    /// SHA-256 of the complete validated tool-call value.
+    pub tool_call_digest: String,
+    /// Effective local user that made the decision.
+    pub actor_uid: u32,
+    /// Once-only decision class; never an Agent option label.
+    pub decision: OncePermissionDecision,
+}
+
+/// Writes permission evidence at a security boundary.
+pub trait PermissionEvidenceSink {
+    /// Persists one record before the caller responds to the Agent.
+    fn record(&mut self, evidence: &PermissionEvidence) -> Result<(), PermissionEvidenceError>;
+}
+
+impl<T: PermissionEvidenceSink + ?Sized> PermissionEvidenceSink for &mut T {
+    fn record(&mut self, evidence: &PermissionEvidence) -> Result<(), PermissionEvidenceError> {
+        (**self).record(evidence)
+    }
+}
+
+/// Presents one local permission interaction.
+pub trait PermissionPresenter {
+    /// Returns a once-only choice. EOF and unavailable interaction must cancel.
+    fn decide(
+        &mut self,
+        prompt: &OncePermissionPrompt,
+    ) -> Result<OncePermissionDecision, PermissionProxyError>;
+}
+
+/// Presenter used when no trusted local terminal is available or prompting is disabled.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct CancelPermissionPresenter;
+
+impl PermissionPresenter for CancelPermissionPresenter {
+    fn decide(
+        &mut self,
+        _prompt: &OncePermissionPrompt,
+    ) -> Result<OncePermissionDecision, PermissionProxyError> {
+        Ok(OncePermissionDecision::Cancelled)
+    }
+}
+
+/// Line-oriented presenter used only with a trusted local terminal.
+#[derive(Debug)]
+pub struct TextPermissionPresenter<R, W> {
+    input: R,
+    output: W,
+}
+
+impl<R, W> TextPermissionPresenter<R, W> {
+    /// Creates a presenter over caller-owned terminal streams.
+    pub fn new(input: R, output: W) -> Self {
+        Self { input, output }
+    }
+}
+
+impl<R: BufRead, W: Write> PermissionPresenter for TextPermissionPresenter<R, W> {
+    fn decide(
+        &mut self,
+        prompt: &OncePermissionPrompt,
+    ) -> Result<OncePermissionDecision, PermissionProxyError> {
+        writeln!(self.output, "Agent requests permission: {}", prompt.title)?;
+        match (prompt.can_allow_once, prompt.can_reject_once) {
+            (true, true) => writeln!(self.output, "Choose [a]llow once / [r]eject once:")?,
+            (true, false) => writeln!(self.output, "Choose [a]llow once / [c]ancel:")?,
+            (false, true) => writeln!(self.output, "Choose [r]eject once / [c]ancel:")?,
+            (false, false) => return Ok(OncePermissionDecision::Cancelled),
+        }
+        self.output.flush()?;
+        let mut line = String::new();
+        if self.input.read_line(&mut line)? == 0 {
+            return Ok(OncePermissionDecision::Cancelled);
+        }
+        Ok(match line.trim().to_ascii_lowercase().as_str() {
+            "a" | "allow" | "allow_once" if prompt.can_allow_once => {
+                OncePermissionDecision::AllowOnce
+            }
+            "r" | "reject" | "reject_once" if prompt.can_reject_once => {
+                OncePermissionDecision::RejectOnce
+            }
+            _ => OncePermissionDecision::Cancelled,
+        })
+    }
+}
+
+/// Fail-closed orchestration for one correlated ACP permission callback.
+#[derive(Debug)]
+pub struct OncePermissionProxy<P, E> {
+    presenter: P,
+    evidence: E,
+}
+
+impl<P, E> OncePermissionProxy<P, E> {
+    /// Creates a proxy whose evidence sink is authoritative for replies.
+    pub fn new(presenter: P, evidence: E) -> Self {
+        Self {
+            presenter,
+            evidence,
+        }
+    }
+}
+
+impl<P: PermissionPresenter, E: PermissionEvidenceSink> OncePermissionProxy<P, E> {
+    /// Resolves one request and persists redacted evidence before returning a reply.
+    ///
+    /// # Errors
+    ///
+    /// Returns presentation, serialization, or durable evidence failures. The
+    /// caller must cancel the callback when an error is returned.
+    pub fn resolve(
+        &mut self,
+        context: PermissionEvidenceContext<'_>,
+        request: &AcpV1PermissionRequest,
+    ) -> Result<AcpV1PermissionDecision, PermissionProxyError> {
+        let allow = request
+            .options
+            .iter()
+            .find(|option| option.kind == AcpV1PermissionOptionKind::AllowOnce);
+        let reject = request
+            .options
+            .iter()
+            .find(|option| option.kind == AcpV1PermissionOptionKind::RejectOnce);
+        let prompt = OncePermissionPrompt {
+            title: bounded_title(&request.tool_call),
+            can_allow_once: allow.is_some(),
+            can_reject_once: reject.is_some(),
+        };
+        let decision = self.presenter.decide(&prompt)?;
+        let selected = match decision {
+            OncePermissionDecision::AllowOnce => allow.map(|option| option.option_id.clone()),
+            OncePermissionDecision::RejectOnce => reject.map(|option| option.option_id.clone()),
+            OncePermissionDecision::Cancelled => None,
+        };
+        let effective = if selected.is_some() {
+            decision
+        } else {
+            OncePermissionDecision::Cancelled
+        };
+        let evidence = evidence(context, request, effective)?;
+        self.evidence.record(&evidence)?;
+        Ok(
+            selected.map_or(AcpV1PermissionDecision::Cancelled, |option_id| {
+                AcpV1PermissionDecision::Selected { option_id }
+            }),
+        )
+    }
+}
+
+/// Trusted fields bound by the local entrypoint for one evidence record.
+#[derive(Debug, Clone, Copy)]
+pub struct PermissionEvidenceContext<'a> {
+    /// Stable built-in profile name.
+    pub profile: &'a str,
+    /// Canonical workspace bytes used only as digest input.
+    pub canonical_workspace: &'a [u8],
+    /// Effective local actor UID.
+    pub actor_uid: u32,
+    /// Current wall-clock milliseconds.
+    pub occurred_at_ms: u64,
+}
+
+/// Failure at the once-only permission boundary.
+#[derive(Debug, Error)]
+pub enum PermissionProxyError {
+    /// Local interaction stream failed.
+    #[error("local permission interaction failed: {0}")]
+    Interaction(#[from] io::Error),
+    /// The validated tool call could not be encoded for correlation.
+    #[error("permission correlation encoding failed: {0}")]
+    Correlation(#[from] serde_json::Error),
+    /// Durable evidence could not be written; no Agent reply is authorized.
+    #[error(transparent)]
+    Evidence(#[from] PermissionEvidenceError),
+}
+
+fn bounded_title(tool_call: &serde_json::Value) -> String {
+    let title = tool_call
+        .get("title")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("Agent tool request");
+    let mut title = title
+        .chars()
+        .filter(|value| !value.is_control())
+        .collect::<String>();
+    if title.len() > MAX_DISPLAY_BYTES {
+        let mut boundary = MAX_DISPLAY_BYTES;
+        while !title.is_char_boundary(boundary) {
+            boundary -= 1;
+        }
+        title.truncate(boundary);
+    }
+    title
+}
+
+fn evidence(
+    context: PermissionEvidenceContext<'_>,
+    request: &AcpV1PermissionRequest,
+    decision: OncePermissionDecision,
+) -> Result<PermissionEvidence, serde_json::Error> {
+    let request_id = match &request.request_id {
+        crate::runtime::AcpV1RequestId::Number(value) => format!("number:{value}"),
+        crate::runtime::AcpV1RequestId::String(value) => format!("string:{value}"),
+    };
+    let tool_call = serde_json::to_vec(&request.tool_call)?;
+    Ok(PermissionEvidence {
+        schema_version: 1,
+        occurred_at_ms: context.occurred_at_ms,
+        profile: context.profile.to_owned(),
+        workspace_digest: digest(context.canonical_workspace),
+        session_digest: digest(request.session_id.as_bytes()),
+        request_digest: digest(request_id.as_bytes()),
+        tool_call_digest: digest(&tool_call),
+        actor_uid: context.actor_uid,
+        decision,
+    })
+}
+
+fn digest(bytes: &[u8]) -> String {
+    use sha2::{Digest as _, Sha256};
+    format!("{:x}", Sha256::digest(bytes))
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/cosh-ng/crates/cosh-gateway/src/permission/evidence.rs
+++ b/src/cosh-ng/crates/cosh-gateway/src/permission/evidence.rs
@@ -1,0 +1,216 @@
+//! Private append-only storage for redacted permission evidence.
+
+use std::fs::{self, File, OpenOptions};
+use std::io::{BufWriter, Write};
+use std::path::{Path, PathBuf};
+
+use nix::fcntl::{Flock, FlockArg};
+use thiserror::Error;
+
+use super::{PermissionEvidence, PermissionEvidenceSink};
+
+const MAX_EVIDENCE_BYTES: usize = 16 * 1024;
+
+/// Safe durable-evidence failure without record contents.
+#[derive(Debug, Error)]
+pub enum PermissionEvidenceError {
+    /// Evidence paths must be explicit and private.
+    #[error("permission evidence path is unsafe")]
+    UnsafePath,
+    /// Evidence encoding exceeded its bounded schema.
+    #[error("permission evidence record exceeds its size bound")]
+    RecordTooLarge,
+    /// Filesystem persistence failed.
+    #[error("permission evidence persistence failed: {0}")]
+    Io(#[from] std::io::Error),
+    /// Evidence serialization failed.
+    #[error("permission evidence serialization failed: {0}")]
+    Serialize(#[from] serde_json::Error),
+}
+
+/// Process-owned writer for one private append-only JSONL evidence file.
+#[derive(Debug)]
+pub struct FilePermissionEvidenceSink {
+    path: PathBuf,
+    writer: BufWriter<LockedFile>,
+}
+
+#[derive(Debug)]
+struct LockedFile(Flock<File>);
+
+impl Write for LockedFile {
+    fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+        Write::write(&mut *self.0, bytes)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Write::flush(&mut *self.0)
+    }
+}
+
+impl LockedFile {
+    fn sync_data(&self) -> std::io::Result<()> {
+        self.0.sync_data()
+    }
+}
+
+impl FilePermissionEvidenceSink {
+    /// Opens a private evidence file below an existing private directory.
+    ///
+    /// # Errors
+    ///
+    /// Rejects relative paths, symlinks, unsafe ownership/mode, and lock errors.
+    pub fn open(path: impl Into<PathBuf>) -> Result<Self, PermissionEvidenceError> {
+        let path = path.into();
+        validate_path(&path)?;
+        let parent = path.parent().ok_or(PermissionEvidenceError::UnsafePath)?;
+        validate_private_directory(parent)?;
+        let mut options = OpenOptions::new();
+        options.append(true).create(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600).custom_flags(nix::libc::O_NOFOLLOW);
+        }
+        let file = options.open(&path)?;
+        validate_private_file(&file)?;
+        let locked = Flock::lock(file, FlockArg::LockExclusiveNonblock)
+            .map_err(|(_, error)| std::io::Error::from_raw_os_error(error as i32))?;
+        Ok(Self {
+            path,
+            writer: BufWriter::new(LockedFile(locked)),
+        })
+    }
+
+    /// Creates the final private state directory when absent, then opens evidence.
+    ///
+    /// # Errors
+    ///
+    /// Rejects non-absolute paths, symlinked state directories, unsafe ownership
+    /// or modes, and filesystem persistence failures.
+    #[cfg(unix)]
+    pub fn open_in_private_state(
+        path: impl Into<PathBuf>,
+    ) -> Result<Self, PermissionEvidenceError> {
+        use std::os::unix::fs::PermissionsExt;
+
+        let path = path.into();
+        validate_path(&path)?;
+        let parent = path.parent().ok_or(PermissionEvidenceError::UnsafePath)?;
+        create_private_directory_chain(parent)?;
+        fs::set_permissions(parent, fs::Permissions::from_mode(0o700))?;
+        validate_private_directory(parent)?;
+        Self::open(path)
+    }
+
+    /// Returns the configured basename without exposing the directory.
+    pub fn basename(&self) -> Option<&str> {
+        self.path.file_name().and_then(|name| name.to_str())
+    }
+}
+
+impl PermissionEvidenceSink for FilePermissionEvidenceSink {
+    fn record(&mut self, evidence: &PermissionEvidence) -> Result<(), PermissionEvidenceError> {
+        let mut bytes = serde_json::to_vec(evidence)?;
+        bytes.push(b'\n');
+        if bytes.len() > MAX_EVIDENCE_BYTES {
+            return Err(PermissionEvidenceError::RecordTooLarge);
+        }
+        self.writer.write_all(&bytes)?;
+        self.writer.flush()?;
+        self.writer.get_ref().sync_data()?;
+        Ok(())
+    }
+}
+
+fn validate_path(path: &Path) -> Result<(), PermissionEvidenceError> {
+    if !path.is_absolute()
+        || path.file_name().is_none()
+        || path.components().any(|part| {
+            matches!(
+                part,
+                std::path::Component::ParentDir | std::path::Component::CurDir
+            )
+        })
+    {
+        return Err(PermissionEvidenceError::UnsafePath);
+    }
+    if fs::symlink_metadata(path).is_ok_and(|metadata| metadata.file_type().is_symlink()) {
+        return Err(PermissionEvidenceError::UnsafePath);
+    }
+    Ok(())
+}
+
+fn validate_private_directory(path: &Path) -> Result<(), PermissionEvidenceError> {
+    let metadata = fs::symlink_metadata(path)?;
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        return Err(PermissionEvidenceError::UnsafePath);
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        if metadata.uid() != nix::unistd::Uid::effective().as_raw() || metadata.mode() & 0o077 != 0
+        {
+            return Err(PermissionEvidenceError::UnsafePath);
+        }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn validate_owned_directory(path: &Path) -> Result<(), PermissionEvidenceError> {
+    use std::os::unix::fs::MetadataExt;
+
+    let metadata = fs::symlink_metadata(path)?;
+    if !metadata.is_dir()
+        || metadata.file_type().is_symlink()
+        || metadata.uid() != nix::unistd::Uid::effective().as_raw()
+        || metadata.mode() & 0o022 != 0
+    {
+        return Err(PermissionEvidenceError::UnsafePath);
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn create_private_directory_chain(path: &Path) -> Result<(), PermissionEvidenceError> {
+    use std::os::unix::fs::DirBuilderExt;
+
+    let mut missing = Vec::new();
+    let mut cursor = path;
+    loop {
+        match fs::symlink_metadata(cursor) {
+            Ok(_) => {
+                validate_owned_directory(cursor)?;
+                break;
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                missing.push(cursor.to_path_buf());
+                cursor = cursor.parent().ok_or(PermissionEvidenceError::UnsafePath)?;
+            }
+            Err(error) => return Err(error.into()),
+        }
+    }
+    for directory in missing.into_iter().rev() {
+        let mut builder = fs::DirBuilder::new();
+        builder.mode(0o700).create(&directory)?;
+        validate_private_directory(&directory)?;
+    }
+    Ok(())
+}
+
+fn validate_private_file(file: &File) -> Result<(), PermissionEvidenceError> {
+    let metadata = file.metadata()?;
+    if !metadata.is_file() {
+        return Err(PermissionEvidenceError::UnsafePath);
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        if metadata.uid() != nix::unistd::Uid::effective().as_raw() || metadata.mode() & 0o077 != 0
+        {
+            return Err(PermissionEvidenceError::UnsafePath);
+        }
+    }
+    Ok(())
+}

--- a/src/cosh-ng/crates/cosh-gateway/src/permission/tests.rs
+++ b/src/cosh-ng/crates/cosh-gateway/src/permission/tests.rs
@@ -1,0 +1,229 @@
+use std::cell::RefCell;
+use std::io::Cursor;
+use std::rc::Rc;
+
+use crate::runtime::{
+    AcpV1PermissionOption, AcpV1PermissionOptionKind, AcpV1PermissionRequest, AcpV1RequestId,
+};
+
+use super::*;
+
+#[derive(Clone, Default)]
+struct MemoryEvidence(Rc<RefCell<Vec<PermissionEvidence>>>);
+
+impl PermissionEvidenceSink for MemoryEvidence {
+    fn record(&mut self, evidence: &PermissionEvidence) -> Result<(), PermissionEvidenceError> {
+        self.0.borrow_mut().push(evidence.clone());
+        Ok(())
+    }
+}
+
+fn request() -> AcpV1PermissionRequest {
+    AcpV1PermissionRequest {
+        request_id: AcpV1RequestId::Number(7),
+        session_id: "provider-session-secret".to_owned(),
+        tool_call: serde_json::json!({
+            "toolCallId": "tool-secret",
+            "title": "Run tests",
+            "rawInput": {"token": "credential-secret"}
+        }),
+        options: vec![
+            AcpV1PermissionOption {
+                option_id: "allow".to_owned(),
+                name: "Always trust me".to_owned(),
+                kind: AcpV1PermissionOptionKind::AllowOnce,
+            },
+            AcpV1PermissionOption {
+                option_id: "reject".to_owned(),
+                name: "Reject".to_owned(),
+                kind: AcpV1PermissionOptionKind::RejectOnce,
+            },
+            AcpV1PermissionOption {
+                option_id: "always".to_owned(),
+                name: "Allow always".to_owned(),
+                kind: AcpV1PermissionOptionKind::AllowAlways,
+            },
+        ],
+    }
+}
+
+fn context() -> PermissionEvidenceContext<'static> {
+    PermissionEvidenceContext {
+        profile: "codex",
+        canonical_workspace: b"/private/workspace",
+        actor_uid: 1000,
+        occurred_at_ms: 123,
+    }
+}
+
+#[test]
+fn allow_once_is_correlated_and_evidence_contains_only_digests() {
+    let output = Rc::new(RefCell::new(Vec::new()));
+    struct SharedOutput(Rc<RefCell<Vec<u8>>>);
+    impl Write for SharedOutput {
+        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+            self.0.borrow_mut().extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+    let presenter = TextPermissionPresenter::new(Cursor::new(b"a\n"), SharedOutput(output));
+    let evidence = MemoryEvidence::default();
+    let captured = evidence.clone();
+    let mut proxy = OncePermissionProxy::new(presenter, evidence);
+
+    assert_eq!(
+        proxy.resolve(context(), &request()).unwrap(),
+        AcpV1PermissionDecision::Selected {
+            option_id: "allow".to_owned()
+        }
+    );
+    let records = captured.0.borrow();
+    assert_eq!(records[0].decision, OncePermissionDecision::AllowOnce);
+    let encoded = serde_json::to_string(&records[0]).unwrap();
+    assert!(!encoded.contains("credential-secret"));
+    assert!(!encoded.contains("provider-session-secret"));
+    assert!(!encoded.contains("/private/workspace"));
+}
+
+#[test]
+fn unsupported_or_eof_choice_cancels_without_durable_rule() {
+    let presenter = TextPermissionPresenter::new(Cursor::new(Vec::<u8>::new()), Vec::<u8>::new());
+    let evidence = MemoryEvidence::default();
+    let captured = evidence.clone();
+    let mut proxy = OncePermissionProxy::new(presenter, evidence);
+
+    assert_eq!(
+        proxy.resolve(context(), &request()).unwrap(),
+        AcpV1PermissionDecision::Cancelled
+    );
+    assert_eq!(
+        captured.0.borrow()[0].decision,
+        OncePermissionDecision::Cancelled
+    );
+}
+
+#[test]
+fn durable_only_options_cannot_be_selected_by_a_spoofed_label() {
+    let mut request = request();
+    request.options.retain(|option| {
+        matches!(
+            option.kind,
+            AcpV1PermissionOptionKind::AllowAlways | AcpV1PermissionOptionKind::RejectAlways
+        )
+    });
+    request.options[0].name = "allow_once".to_owned();
+    let evidence = MemoryEvidence::default();
+    let captured = evidence.clone();
+    let mut proxy = OncePermissionProxy::new(
+        TextPermissionPresenter::new(Cursor::new(b"a\n"), Vec::<u8>::new()),
+        evidence,
+    );
+
+    assert_eq!(
+        proxy.resolve(context(), &request).unwrap(),
+        AcpV1PermissionDecision::Cancelled
+    );
+    assert_eq!(
+        captured.0.borrow()[0].decision,
+        OncePermissionDecision::Cancelled
+    );
+}
+
+#[test]
+fn terminal_title_is_bounded_and_strips_control_injection() {
+    let mut request = request();
+    request.tool_call["title"] = serde_json::Value::String(format!(
+        "safe\u{1b}[2J\r{}",
+        "x".repeat(MAX_DISPLAY_BYTES * 2)
+    ));
+    let output = Rc::new(RefCell::new(Vec::new()));
+    struct SharedOutput(Rc<RefCell<Vec<u8>>>);
+    impl Write for SharedOutput {
+        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+            self.0.borrow_mut().extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+    let presenter =
+        TextPermissionPresenter::new(Cursor::new(b"r\n"), SharedOutput(Rc::clone(&output)));
+    let mut proxy = OncePermissionProxy::new(presenter, MemoryEvidence::default());
+    proxy.resolve(context(), &request).unwrap();
+
+    let rendered = output.borrow();
+    assert!(!rendered.contains(&0x1b));
+    assert!(!rendered.contains(&b'\r'));
+    assert!(rendered.len() < MAX_DISPLAY_BYTES + 128);
+}
+
+#[cfg(unix)]
+#[test]
+fn file_evidence_requires_private_directory_and_syncs_jsonl() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let root = tempfile::tempdir().unwrap();
+    std::fs::set_permissions(root.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+    let path = root.path().join("permission.jsonl");
+    let mut sink = FilePermissionEvidenceSink::open(&path).unwrap();
+    let mut proxy = OncePermissionProxy::new(
+        TextPermissionPresenter::new(Cursor::new(b"r\n"), Vec::<u8>::new()),
+        &mut sink,
+    );
+    assert_eq!(
+        proxy.resolve(context(), &request()).unwrap(),
+        AcpV1PermissionDecision::Selected {
+            option_id: "reject".to_owned()
+        }
+    );
+    drop(proxy);
+    drop(sink);
+    let content = std::fs::read_to_string(path).unwrap();
+    assert!(content.contains("\"reject_once\""));
+    assert!(!content.contains("credential-secret"));
+}
+
+#[cfg(unix)]
+#[test]
+fn evidence_rejects_symlink_and_public_existing_file() {
+    use std::os::unix::fs::{symlink, PermissionsExt};
+
+    let root = tempfile::tempdir().unwrap();
+    std::fs::set_permissions(root.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+    let target = root.path().join("target.jsonl");
+    std::fs::write(&target, "").unwrap();
+    let link = root.path().join("link.jsonl");
+    symlink(&target, &link).unwrap();
+    assert!(matches!(
+        FilePermissionEvidenceSink::open(link),
+        Err(PermissionEvidenceError::UnsafePath)
+    ));
+
+    std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o644)).unwrap();
+    assert!(matches!(
+        FilePermissionEvidenceSink::open(target),
+        Err(PermissionEvidenceError::UnsafePath)
+    ));
+}
+
+#[cfg(unix)]
+#[test]
+fn private_state_creation_rejects_symlinked_parent() {
+    use std::os::unix::fs::{symlink, PermissionsExt};
+
+    let root = tempfile::tempdir().unwrap();
+    std::fs::set_permissions(root.path(), std::fs::Permissions::from_mode(0o700)).unwrap();
+    let target = root.path().join("target");
+    std::fs::create_dir(&target).unwrap();
+    std::fs::set_permissions(&target, std::fs::Permissions::from_mode(0o700)).unwrap();
+    let link = root.path().join("state");
+    symlink(&target, &link).unwrap();
+    assert!(matches!(
+        FilePermissionEvidenceSink::open_in_private_state(link.join("permission.jsonl")),
+        Err(PermissionEvidenceError::UnsafePath)
+    ));
+}

--- a/src/cosh-ng/crates/cosh-gateway/tests/cli_entrypoint.rs
+++ b/src/cosh-ng/crates/cosh-gateway/tests/cli_entrypoint.rs
@@ -37,6 +37,38 @@ done
     path
 }
 
+fn permission_adapter(directory: &tempfile::TempDir) -> (std::path::PathBuf, std::path::PathBuf) {
+    let path = directory.path().join("codex-acp");
+    let response = directory.path().join("permission-response.json");
+    let script = r#"#!/bin/sh
+step=0
+while IFS= read -r line; do
+    step=$((step + 1))
+    case "$step" in
+        1)
+            printf '%s\n' '{"jsonrpc":"2.0","id":"cosh-acp-1","result":{"protocolVersion":1,"agentCapabilities":{}}}'
+            ;;
+        2)
+            printf '%s\n' '{"jsonrpc":"2.0","id":"cosh-acp-2","result":{"sessionId":"permission-session"}}'
+            ;;
+        3)
+            printf '%s\n' '{"jsonrpc":"2.0","id":99,"method":"session/request_permission","params":{"sessionId":"permission-session","toolCall":{"toolCallId":"private-tool-id","title":"Run private operation","rawInput":{"token":"credential-secret"}},"options":[{"optionId":"allow","name":"Allow once","kind":"allow_once"},{"optionId":"always","name":"Allow always","kind":"allow_always"},{"optionId":"reject","name":"Reject once","kind":"reject_once"}]}}'
+            ;;
+        4)
+            printf '%s\n' "$line" > '__RESPONSE__'
+            printf '%s\n' '{"jsonrpc":"2.0","id":"cosh-acp-3","result":{"stopReason":"end_turn"}}'
+            ;;
+    esac
+done
+"#
+    .replace("__RESPONSE__", response.to_str().unwrap());
+    fs::write(&path, script).unwrap();
+    let mut permissions = fs::metadata(&path).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&path, permissions).unwrap();
+    (path, response)
+}
+
 #[test]
 fn doctor_initializes_installed_adapter_without_prompting() {
     let workspace = tempfile::tempdir().unwrap();
@@ -129,4 +161,86 @@ fn missing_adapter_has_stable_profile_exit_and_jsonl_error() {
     let stdout = String::from_utf8(output.stdout).unwrap();
     assert!(stdout.contains("\"event\":\"error\""));
     assert!(stdout.contains("\"code\":\"profile_invalid\""));
+}
+
+#[test]
+fn noninteractive_permission_cancels_and_persists_only_digests() {
+    let workspace = tempfile::tempdir().unwrap();
+    let (adapter, response) = permission_adapter(&workspace);
+    let evidence = workspace.path().join("permission-evidence.jsonl");
+    let mut child = Command::new(env!("CARGO_BIN_EXE_cosh-gateway"))
+        .args([
+            "run",
+            "--adapter",
+            adapter.to_str().unwrap(),
+            "--workspace",
+            workspace.path().to_str().unwrap(),
+            "--output",
+            "jsonl",
+            "--permission",
+            "deny",
+            "--permission-evidence",
+            evidence.to_str().unwrap(),
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(b"private prompt\n")
+        .unwrap();
+    let output = child.wait_with_output().unwrap();
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("\"event\":\"permission_decided\""));
+    assert!(stdout.contains("\"decision\":\"cancelled\""));
+    assert!(!stdout.contains("private-tool-id"));
+    assert!(!stdout.contains("credential-secret"));
+
+    let stored = fs::read_to_string(evidence).unwrap();
+    assert!(stored.contains("\"decision\":\"cancelled\""));
+    assert!(stored.contains("\"workspace_digest\""));
+    assert!(!stored.contains("permission-session"));
+    assert!(!stored.contains("private-tool-id"));
+    assert!(!stored.contains("credential-secret"));
+    let answer = fs::read_to_string(response).unwrap();
+    assert!(answer.contains("\"id\":99"));
+    assert!(answer.contains("cancelled"));
+}
+
+#[test]
+fn relative_permission_evidence_path_fails_before_adapter_launch() {
+    let workspace = tempfile::tempdir().unwrap();
+    let adapter = workspace.path().join("codex-acp");
+    fs::write(&adapter, "#!/bin/sh\ntouch launched\n").unwrap();
+    let mut permissions = fs::metadata(&adapter).unwrap().permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&adapter, permissions).unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_cosh-gateway"))
+        .current_dir(workspace.path())
+        .args([
+            "run",
+            "--adapter",
+            adapter.to_str().unwrap(),
+            "--workspace",
+            workspace.path().to_str().unwrap(),
+            "--permission-evidence",
+            "relative.jsonl",
+        ])
+        .stdin(Stdio::piped())
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(12));
+    assert!(!workspace.path().join("launched").exists());
+    assert!(!workspace.path().join("relative.jsonl").exists());
 }

--- a/src/cosh-ng/docs/design/acp-v1-phase-0-2/phase-1/acp-mvp/acceptance.md
+++ b/src/cosh-ng/docs/design/acp-v1-phase-0-2/phase-1/acp-mvp/acceptance.md
@@ -7,9 +7,10 @@
 
 **PARTIAL IMPLEMENTATION / NOT ACCEPTED.** The candidate has a strict ACP v1
 codec, supervised stdio bridge, bounded session driver with independent
-cancellation, deterministic fake-Agent fixtures, and built-in profile
-resolution for `codex-acp` and `claude-agent-acp`. It has no installed COSH
-entrypoint, local permission UI/evidence record, or real-adapter evidence.
+cancellation, an installed COSH entrypoint, and built-in profile resolution
+for `codex-acp` and `claude-agent-acp`. A local once-only permission proxy
+writes redacted evidence before reply. No real-Adapter provider run is
+recorded.
 
 This gate is independent from complete G1 and G2 acceptance. Passing it will
 prove only the narrow local interoperability outcome defined in the design.
@@ -30,13 +31,14 @@ prove only the narrow local interoperability outcome defined in the design.
 | --- | --- | --- |
 | ACP v1 codec | `PARTIAL` | Exact wire v1 initialization, one session, text prompt/update/stop, bounds, and malformed-input handling have focused fixtures; no real adapter run |
 | Supervised stdio | `PARTIAL` | The bridge composes one supervisor and a bounded driver with deadlines/backpressure; broader race and process-tree fixtures remain |
-| Runtime profiles | `PARTIAL` | Built-in resolver pins `codex-acp` and `claude-agent-acp`, canonical executable/workspace, fixed args, and environment allowlists; no installed user entrypoint |
+| Runtime profiles | `PARTIAL` | The installed entrypoint uses built-in resolver profiles that pin `codex-acp` and `claude-agent-acp`, canonical executable/workspace, fixed args, and environment allowlists; installed-package smoke evidence remains |
 | Streaming | `PARTIAL` | A bounded driver delivers decoded observations in receive order and fails closed on saturation; local sequence and presentation are incomplete |
 | Cancellation | `PARTIAL` | Independent control reaches a silent Agent, settles pending permission callbacks, and reaps the process; wider race coverage remains |
-| Permission correlation | `PARTIAL` | Offered request/option IDs are checked, durable options are rejected, and responses are single-use; no local user decision surface or evidence record |
+| Permission correlation | `PASS for local slice` | Local TTY presentation retains only correlated `allow_once`/`reject_once`; non-TTY, EOF, unsupported-only options, and explicit deny cancel |
+| Permission evidence | `PASS for local slice` | Private append-only JSONL records bounded hashes, actor UID, and decision class before reply; raw prompt/tool/session/workspace values are excluded |
 | Unsupported callbacks | `PARTIAL` | Fake fs request receives correlated method-not-found; complete fs/terminal non-advertisement matrix remains |
-| Real adapter conformance | `NOT RUN` | No exact-version `codex-acp` or `claude-agent-acp` transcript is recorded |
-| Rollback | `PARTIAL` | Existing direct `cosh-shell raw cosh-core` path remains; no installed ACP entrypoint smoke test |
+| Real adapter conformance | `NOT RUN` | No exact-version `codex-acp` or `claude-agent-acp` provider run is recorded |
+| Rollback | `PARTIAL` | Existing direct `cosh-shell raw cosh-core` path remains and raw-package routing is tested; an installed-package smoke remains |
 
 Source presence is not user-facing acceptance. Profile resolver tests that use
 temporary executable files do not prove an installed official adapter works.
@@ -45,16 +47,16 @@ temporary executable files do not prove an installed official adapter works.
 
 | ID | Criterion | Current result | Required proof |
 | --- | --- | --- | --- |
-| MVP-01 | One installed COSH entrypoint accepts a built-in profile, canonical workspace, and bounded text prompt | `NOT IMPLEMENTED` | Installed-binary integration test and `--help`/contract fixture |
-| MVP-02 | Only locally installed `codex-acp` or `claude-agent-acp` is launched; native Codex/Claude, `npx`, shell, package runner, and network bootstrap are impossible | `PARTIAL` | Resolver source/tests plus entrypoint dependency and process-spawn review |
+| MVP-01 | One installed COSH entrypoint accepts a built-in profile, canonical workspace, and bounded text prompt | `PARTIAL` | Binary integration and raw-package routing pass; installed-package smoke remains |
+| MVP-02 | Only locally installed `codex-acp` or `claude-agent-acp` is launched; native Codex/Claude, `npx`, shell, package runner, and network bootstrap are impossible | `PARTIAL` | Runtime resolver never bootstraps packages; distribution and installed-package proof remain |
 | MVP-03 | Profile resolution pins exact basename, canonical executable/workspace, fixed args, and allowlisted environment without logging values | `PARTIAL` | Positive and spoof/path/environment tests on the entrypoint path |
 | MVP-04 | Driver performs ACP v1 initialize, one session/new, and one active text prompt in order | `PARTIAL` | End-to-end driver fixture with wrong-order and duplicate-prompt negatives |
 | MVP-05 | Text updates are delivered in receive order with bounded local sequence, queue depth, and bytes | `NOT IMPLEMENTED` | Multi-chunk and saturation fixtures |
 | MVP-06 | Every turn reports exactly one terminal result and rejects late updates | `PARTIAL` | Completion/cancel/error/exit/timeout race matrix |
 | MVP-07 | Cancel reaches the driver while Agent stdout is silent and settles protocol/process state within configured bounds | `PARTIAL` | Independent-control fake-Agent test passes; completion/cancel race matrix remains |
 | MVP-08 | Cancel settles every pending permission and no late decision or update can authorize work | `PARTIAL` | Permission-during-cancel and late-response race fixtures |
-| MVP-09 | Permission proxy offers only correlated `allow_once` and `reject_once`; `allow_always` and `reject_always` cannot create a decision or rule | `NOT IMPLEMENTED` | Local decision-surface and unsupported-option tests |
-| MVP-10 | Permission evidence is bounded, redacted, and records request correlation plus decision class | `NOT IMPLEMENTED` | Evidence schema, secret/log injection, and bounds tests |
+| MVP-09 | Permission proxy offers only correlated `allow_once` and `reject_once`; `allow_always` and `reject_always` cannot create a decision or rule | `PASS for local slice` | Seven focused proxy/evidence tests plus non-interactive entrypoint cancellation |
+| MVP-10 | Permission evidence is bounded, redacted, and records request correlation plus decision class | `PASS for local slice` | Private-file, symlink, mode, secret exclusion, control-injection, and entrypoint evidence tests |
 | MVP-11 | fs, terminal, load, resume, rich content, additional directories, and multiple sessions remain unadvertised and fail closed | `PARTIAL` | Complete capability/request negative matrix with zero host I/O |
 | MVP-12 | Malformed/oversized/invalid UTF-8/contaminated stdout, stderr flood, child exit, and timeout terminate safely with one reaped child | `PARTIAL` | Adversarial process fixtures and leak assertions |
 | MVP-13 | At least one installed real adapter completes initialize, prompt, multiple streamed text updates, terminal result, active cancel, allow once, and reject once | `NOT RUN` | Sanitized exact-version transcript and command results at candidate SHA |
@@ -111,6 +113,26 @@ Acceptance requires one locally installed `codex-acp` or
 Provider output, prompts, credentials, environment values, host identifiers,
 and private workspace contents must be removed from evidence.
 
+## Stage 2 permission evidence
+
+`cosh agent run` defaults to local `/dev/tty` presentation and offers only
+Agent-provided `allow_once` and `reject_once` choices. `--permission deny`, no
+TTY, EOF, invalid input, and unsupported-only options cancel without
+authorization. The callback reply is sent only after a private append-only
+JSONL record is synchronized. That record contains correlation hashes, actor
+UID, profile, time, and decision class; it excludes raw prompt, tool arguments,
+option labels, provider session identifiers, and workspace paths.
+
+Targeted Stage 2 checks:
+
+```bash
+cargo +1.88.0 test --locked --package cosh-gateway permission:: --lib
+# 7 passed
+cargo +1.88.0 test --locked --package cosh-gateway \
+  --test cli_entrypoint --bin cosh-gateway
+# 7 passed
+```
+
 ## Exit criteria
 
 The ACP MVP is accepted only when:
@@ -125,9 +147,8 @@ The ACP MVP is accepted only when:
 5. The report states explicitly that the result is not G1/G2, durable
    governance, filesystem/terminal, Web, Shell attachment, or daemon acceptance.
 
-## Documentation validation for this slice
+## Documentation validation
 
-The documentation-only change must pass repository docs lint, relative-link
-checking, bilingual pairing/parity review, and `git diff --check`. It does not
-run Cargo, a provider, ECS, or a real adapter and cannot change MVP-13 from
-`NOT RUN`.
+The bilingual documents must pass repository docs lint, relative-link checking,
+pairing/parity review, and `git diff --check`. Stage 2 does not run a provider,
+ECS, or a real Adapter and cannot change MVP-13 from `NOT RUN`.

--- a/src/cosh-ng/docs/design/acp-v1-phase-0-2/phase-1/acp-mvp/acceptance_zh.md
+++ b/src/cosh-ng/docs/design/acp-v1-phase-0-2/phase-1/acp-mvp/acceptance_zh.md
@@ -6,9 +6,10 @@
 ## 结果
 
 **PARTIAL IMPLEMENTATION / NOT ACCEPTED。** 候选树已有严格 ACP v1 codec、
-supervised stdio Bridge、带独立 cancellation 的有界 Session Driver、确定性 fake-Agent
-fixture，以及面向 `codex-acp` 和 `claude-agent-acp` 的内置 profile resolver。它仍没有
-已安装 COSH entrypoint、local permission UI/evidence record 或真实 Adapter 证据。
+supervised stdio Bridge、带独立 cancellation 的有界 Session Driver、已安装 COSH
+entrypoint，以及面向 `codex-acp` 和 `claude-agent-acp` 的内置 profile resolver。
+Local once-only Permission Proxy 会在回复前写入脱敏 evidence，但尚未记录真实 Adapter
+provider run。
 
 本 Gate 独立于完整 G1 与 G2 验收。即使通过，也只证明设计中定义的窄范围本地互操作结果。
 
@@ -28,13 +29,14 @@ fixture，以及面向 `codex-acp` 和 `claude-agent-acp` 的内置 profile reso
 | --- | --- | --- |
 | ACP v1 codec | `PARTIAL` | Exact wire v1 initialization、单 session、text prompt/update/stop、bound 与 malformed-input handling 有 focused fixture；未运行真实 Adapter |
 | Supervised stdio | `PARTIAL` | Bridge 组合一个 Supervisor 与带 deadline/backpressure 的有界 Driver；更广的 race 与 process-tree fixture 仍缺 |
-| Runtime profile | `PARTIAL` | 内置 resolver 固定 `codex-acp` 与 `claude-agent-acp`、canonical executable/workspace、fixed args 与 environment allowlist；无已安装用户 entrypoint |
+| Runtime profile | `PARTIAL` | 已安装 entrypoint 使用内置 resolver，固定 `codex-acp` 与 `claude-agent-acp`、canonical executable/workspace、fixed args 与 environment allowlist；installed-package smoke 证据仍缺 |
 | Streaming | `PARTIAL` | 有界 Driver 按接收顺序交付 decoded observation，saturation 时 fail closed；local sequence 与 presentation 未完成 |
 | Cancellation | `PARTIAL` | Independent control 能触达 silent Agent、结算 pending permission callback 并 reap process；更广 race coverage 仍缺 |
-| Permission correlation | `PARTIAL` | Offered request/option ID 已校验，durable option 被拒绝且 response single-use；无 local user decision surface 或 evidence record |
+| Permission correlation | `PASS for local slice` | Local TTY presentation 只保留有关联的 `allow_once`/`reject_once`；non-TTY、EOF、unsupported-only option 与 explicit deny 都会取消 |
+| Permission evidence | `PASS for local slice` | Private append-only JSONL 在回复前记录 bounded hash、actor UID 与 decision class；不含 raw prompt/tool/session/workspace value |
 | Unsupported callback | `PARTIAL` | Fake fs request 收到有关联 method-not-found；完整 fs/terminal non-advertisement matrix 待补 |
-| 真实 Adapter conformance | `NOT RUN` | 未记录 exact-version `codex-acp` 或 `claude-agent-acp` transcript |
-| Rollback | `PARTIAL` | 现有 direct `cosh-shell raw cosh-core` path 保留；无已安装 ACP entrypoint smoke test |
+| 真实 Adapter conformance | `NOT RUN` | 未记录 exact-version `codex-acp` 或 `claude-agent-acp` provider run |
+| Rollback | `PARTIAL` | 现有 direct `cosh-shell raw cosh-core` path 保留，raw-package routing 已测试；installed-package smoke 仍缺 |
 
 Source 存在不等于用户侧验收。使用临时 executable file 的 profile resolver test 不能证明
 已安装官方 Adapter 可工作。
@@ -43,16 +45,16 @@ Source 存在不等于用户侧验收。使用临时 executable file 的 profile
 
 | ID | Criterion | 当前结果 | 必需证明 |
 | --- | --- | --- | --- |
-| MVP-01 | 一个已安装 COSH entrypoint 接受内置 profile、canonical workspace 与 bounded text prompt | `NOT IMPLEMENTED` | Installed-binary integration test 与 `--help`/contract fixture |
-| MVP-02 | 只启动本地已安装 `codex-acp` 或 `claude-agent-acp`；不可能启动原生 Codex/Claude、`npx`、shell、package runner 或 network bootstrap | `PARTIAL` | Resolver source/test 加 entrypoint dependency 与 process-spawn review |
+| MVP-01 | 一个已安装 COSH entrypoint 接受内置 profile、canonical workspace 与 bounded text prompt | `PARTIAL` | Binary integration 与 raw-package routing 通过；installed-package smoke 仍缺 |
+| MVP-02 | 只启动本地已安装 `codex-acp` 或 `claude-agent-acp`；不可能启动原生 Codex/Claude、`npx`、shell、package runner 或 network bootstrap | `PARTIAL` | Runtime resolver 从不 bootstrap package；distribution 与 installed-package proof 仍缺 |
 | MVP-03 | Profile resolve 固定 exact basename、canonical executable/workspace、fixed args 与 allowlisted environment，且不记录 value | `PARTIAL` | Entrypoint path 的 positive 与 spoof/path/environment test |
 | MVP-04 | Driver 按序执行 ACP v1 initialize、单 session/new 与单 active text prompt | `PARTIAL` | End-to-end Driver fixture 以及 wrong-order/duplicate-prompt negative |
 | MVP-05 | Text update 按接收顺序交付，带有界 local sequence、queue depth 与 byte | `NOT IMPLEMENTED` | Multi-chunk 与 saturation fixture |
 | MVP-06 | 每轮只报告一个 terminal result，并拒绝 late update | `PARTIAL` | Completion/cancel/error/exit/timeout race matrix |
 | MVP-07 | Agent stdout 静默时 cancel 仍到达 Driver，并在配置 bound 内 settle protocol/process state | `PARTIAL` | Independent-control fake-Agent test 通过；completion/cancel race matrix 仍缺 |
 | MVP-08 | Cancel 结算所有 pending permission，late decision/update 不能授权工作 | `PARTIAL` | Permission-during-cancel 与 late-response race fixture |
-| MVP-09 | Permission Proxy 只提供有关联的 `allow_once` 与 `reject_once`；`allow_always`/`reject_always` 不能生成 decision 或 rule | `NOT IMPLEMENTED` | Local decision surface 与 unsupported-option test |
-| MVP-10 | Permission evidence 有界、脱敏，并记录 request correlation 与 decision class | `NOT IMPLEMENTED` | Evidence schema、secret/log injection 与 bounds test |
+| MVP-09 | Permission Proxy 只提供有关联的 `allow_once` 与 `reject_once`；`allow_always`/`reject_always` 不能生成 decision 或 rule | `PASS for local slice` | 七个 focused Proxy/evidence test 与 non-interactive entrypoint cancellation |
+| MVP-10 | Permission evidence 有界、脱敏，并记录 request correlation 与 decision class | `PASS for local slice` | Private-file、symlink、mode、secret exclusion、control-injection 与 entrypoint evidence test |
 | MVP-11 | fs、terminal、load、resume、rich content、additional directory 与 multiple session 保持不声明并 fail closed | `PARTIAL` | 完整 capability/request negative matrix 与 zero host I/O |
 | MVP-12 | Malformed/oversized/invalid UTF-8/contaminated stdout、stderr flood、child exit 与 timeout 安全终止并只 reap 一个 child | `PARTIAL` | Adversarial process fixture 与 leak assertion |
 | MVP-13 | 至少一个已安装真实 Adapter 完成 initialize、prompt、多个 streamed text update、terminal、active cancel、allow once 与 reject once | `NOT RUN` | Candidate SHA 上的脱敏 exact-version transcript 与 command result |
@@ -105,6 +107,25 @@ Fake-Agent corpus 必须包含：
 Evidence 必须移除 provider output、prompt、credential、environment value、host identifier
 与 private workspace content。
 
+## Stage 2 Permission 证据
+
+`cosh agent run` 默认在本地 `/dev/tty` 上呈现，只提供 Agent 实际给出的
+`allow_once` 与 `reject_once` choice。`--permission deny`、没有 TTY、EOF、无效输入与
+unsupported-only option 都会取消且不授权。只有 private append-only JSONL record 完成
+同步后才回复 callback。Record 只包含 correlation hash、actor UID、profile、time 与
+decision class，不含 raw prompt、tool argument、option label、provider session identifier
+或 workspace path。
+
+Stage 2 targeted check：
+
+```bash
+cargo +1.88.0 test --locked --package cosh-gateway permission:: --lib
+# 7 passed
+cargo +1.88.0 test --locked --package cosh-gateway \
+  --test cli_entrypoint --bin cosh-gateway
+# 7 passed
+```
+
 ## Exit Criteria
 
 ACP MVP 只在以下条件全部成立时接受：
@@ -117,8 +138,8 @@ ACP MVP 只在以下条件全部成立时接受：
 5. 报告明确说明该结果不是 G1/G2、durable governance、filesystem/terminal、Web、
    Shell Attachment 或 daemon acceptance。
 
-## 本切片文档验证
+## 文档验证
 
-本次 documentation-only change 必须通过仓库 docs lint、relative-link check、双语 pairing/parity
-review 与 `git diff --check`。它不运行 Cargo、provider、ECS 或真实 Adapter，因此不能把
-MVP-13 从 `NOT RUN` 改为通过。
+双语文档必须通过仓库 docs lint、relative-link check、pairing/parity review 与
+`git diff --check`。Stage 2 不运行 provider、ECS 或真实 Adapter，因此不能把 MVP-13
+从 `NOT RUN` 改为通过。


### PR DESCRIPTION
## Why

ACP tool permission callbacks need an explicit local decision and durable audit
evidence before COSH can safely relay an adapter choice.

## What changed

- Present only correlated `allow_once` and `reject_once` choices on `/dev/tty`.
- Cancel on non-TTY, EOF, unsupported choices, or evidence failure.
- Persist bounded redacted evidence in a private append-only local state file.

## Related issue

no-issue: Stage 2 implementation from the audited ACP plan

## User / Agent impact

`cosh agent run` can now obtain a one-shot local decision without consuming the
prompt stream and records only digests plus the decision class.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed

All unavailable or untrusted interaction paths fail closed. No durable allow
rule is created.

## Validation

- 7 focused permission/evidence tests on Rust 1.88.0
- 2 non-interactive entrypoint permission tests
- clean detached-worktree all-target Clippy with `-D warnings`
- documentation lint, link, and diff checks

## Documentation and rollback

Updated bilingual component, user, and MVP acceptance documentation. Revert
this single commit to restore default callback cancellation.