### PR TITLE
feat(cosh-ng): [gateway] pin ACP adapters

### DIFF
--- a/src/cosh-ng/docs/design/acp-v1-phase-0-2/phase-1/acp-mvp/acceptance.md
+++ b/src/cosh-ng/docs/design/acp-v1-phase-0-2/phase-1/acp-mvp/acceptance.md
@@ -8,9 +8,10 @@
 **PARTIAL IMPLEMENTATION / NOT ACCEPTED.** The candidate has a strict ACP v1
 codec, supervised stdio bridge, bounded session driver with independent
 cancellation, an installed COSH entrypoint, and built-in profile resolution
-for `codex-acp` and `claude-agent-acp`. A local once-only permission proxy
-writes redacted evidence before reply. No real-Adapter provider run is
-recorded.
+for `codex-acp` and `claude-agent-acp`. A source-tree installer pins the
+official Adapter packages, a deterministic harness exercises the entrypoint,
+and a local once-only permission proxy writes redacted evidence before reply.
+No real-Adapter provider run is recorded.
 
 This gate is independent from complete G1 and G2 acceptance. Passing it will
 prove only the narrow local interoperability outcome defined in the design.
@@ -37,7 +38,8 @@ prove only the narrow local interoperability outcome defined in the design.
 | Permission correlation | `PASS for local slice` | Local TTY presentation retains only correlated `allow_once`/`reject_once`; non-TTY, EOF, unsupported-only options, and explicit deny cancel |
 | Permission evidence | `PASS for local slice` | Private append-only JSONL records bounded hashes, actor UID, and decision class before reply; raw prompt/tool/session/workspace values are excluded |
 | Unsupported callbacks | `PARTIAL` | Fake fs request receives correlated method-not-found; complete fs/terminal non-advertisement matrix remains |
-| Real adapter conformance | `NOT RUN` | No exact-version `codex-acp` or `claude-agent-acp` provider run is recorded |
+| Adapter distribution | `PARTIAL` | Source installer uses an exact npm lockfile, a private managed prefix, scripts disabled during install, and package/version/bin provenance checks; the repository does not yet distribute a signed offline Adapter artifact |
+| Real adapter conformance | `NOT RUN` | An opt-in, non-persisting harness exists, but no exact-version `codex-acp` or `claude-agent-acp` provider run is recorded |
 | Rollback | `PARTIAL` | Existing direct `cosh-shell raw cosh-core` path remains and raw-package routing is tested; an installed-package smoke remains |
 
 Source presence is not user-facing acceptance. Profile resolver tests that use
@@ -48,7 +50,7 @@ temporary executable files do not prove an installed official adapter works.
 | ID | Criterion | Current result | Required proof |
 | --- | --- | --- | --- |
 | MVP-01 | One installed COSH entrypoint accepts a built-in profile, canonical workspace, and bounded text prompt | `PARTIAL` | Binary integration and raw-package routing pass; installed-package smoke remains |
-| MVP-02 | Only locally installed `codex-acp` or `claude-agent-acp` is launched; native Codex/Claude, `npx`, shell, package runner, and network bootstrap are impossible | `PARTIAL` | Runtime resolver never bootstraps packages; distribution and installed-package proof remain |
+| MVP-02 | Only locally installed `codex-acp` or `claude-agent-acp` is launched; native Codex/Claude, `npx`, shell, package runner, and network bootstrap are impossible | `PARTIAL` | Runtime resolver never bootstraps packages; the explicit installer pins and verifies both Adapter packages, but signed/offline distribution remains |
 | MVP-03 | Profile resolution pins exact basename, canonical executable/workspace, fixed args, and allowlisted environment without logging values | `PARTIAL` | Positive and spoof/path/environment tests on the entrypoint path |
 | MVP-04 | Driver performs ACP v1 initialize, one session/new, and one active text prompt in order | `PARTIAL` | End-to-end driver fixture with wrong-order and duplicate-prompt negatives |
 | MVP-05 | Text updates are delivered in receive order with bounded local sequence, queue depth, and bytes | `NOT IMPLEMENTED` | Multi-chunk and saturation fixtures |
@@ -133,6 +135,32 @@ cargo +1.88.0 test --locked --package cosh-gateway \
 # 7 passed
 ```
 
+## Stage 3 Adapter evidence
+
+The source installer pins `@agentclientprotocol/codex-acp` at `1.2.0` and
+`@agentclientprotocol/claude-agent-acp` at `0.66.0` through the committed
+lockfile. It accepts only an explicit absolute private prefix and rejects a
+symlinked, non-owned, group/world-accessible, or unrelated non-empty prefix.
+After `npm ci --ignore-scripts`, it verifies each package name, version, and
+canonical `bin` target. npm is never available to the COSH runtime resolver.
+
+Fake conformance validates initialization, session creation, two ordered text
+chunks, prompt completion, and exactly one terminal event. Real mode is
+opt-in, requires a piped prompt plus `--acknowledge-provider-run`, verifies
+exact package provenance, and reduces JSONL to event counts in memory. It does
+not create an evidence file or echo prompt or Agent text.
+
+```bash
+bash src/cosh-ng/tests/test-acp-adapters.sh
+src/cosh-ng/scripts/run-acp-conformance.sh fake \
+  --gateway "$PWD/src/cosh-ng/target/debug/cosh-gateway" \
+  --workspace "$PWD"
+```
+
+These checks use a fake npm implementation and deterministic fake Agent. They
+do not install from the network, invoke a provider, or change MVP-13 from
+`NOT RUN`.
+
 ## Exit criteria
 
 The ACP MVP is accepted only when:
@@ -150,5 +178,5 @@ The ACP MVP is accepted only when:
 ## Documentation validation
 
 The bilingual documents must pass repository docs lint, relative-link checking,
-pairing/parity review, and `git diff --check`. Stage 2 does not run a provider,
+pairing/parity review, and `git diff --check`. Stage 3 does not run a provider,
 ECS, or a real Adapter and cannot change MVP-13 from `NOT RUN`.

--- a/src/cosh-ng/docs/design/acp-v1-phase-0-2/phase-1/acp-mvp/acceptance_zh.md
+++ b/src/cosh-ng/docs/design/acp-v1-phase-0-2/phase-1/acp-mvp/acceptance_zh.md
@@ -8,7 +8,8 @@
 **PARTIAL IMPLEMENTATION / NOT ACCEPTED。** 候选树已有严格 ACP v1 codec、
 supervised stdio Bridge、带独立 cancellation 的有界 Session Driver、已安装 COSH
 entrypoint，以及面向 `codex-acp` 和 `claude-agent-acp` 的内置 profile resolver。
-Local once-only Permission Proxy 会在回复前写入脱敏 evidence，但尚未记录真实 Adapter
+Source-tree installer 固定官方 Adapter package，确定性 harness 会验证 entrypoint，
+local once-only Permission Proxy 会在回复前写入脱敏 evidence，但尚未记录真实 Adapter
 provider run。
 
 本 Gate 独立于完整 G1 与 G2 验收。即使通过，也只证明设计中定义的窄范围本地互操作结果。
@@ -35,7 +36,8 @@ provider run。
 | Permission correlation | `PASS for local slice` | Local TTY presentation 只保留有关联的 `allow_once`/`reject_once`；non-TTY、EOF、unsupported-only option 与 explicit deny 都会取消 |
 | Permission evidence | `PASS for local slice` | Private append-only JSONL 在回复前记录 bounded hash、actor UID 与 decision class；不含 raw prompt/tool/session/workspace value |
 | Unsupported callback | `PARTIAL` | Fake fs request 收到有关联 method-not-found；完整 fs/terminal non-advertisement matrix 待补 |
-| 真实 Adapter conformance | `NOT RUN` | 未记录 exact-version `codex-acp` 或 `claude-agent-acp` provider run |
+| Adapter distribution | `PARTIAL` | Source installer 使用 exact npm lockfile、private managed prefix、安装时禁用 script，并校验 package/version/bin provenance；仓库尚未分发 signed offline Adapter artifact |
+| 真实 Adapter conformance | `NOT RUN` | 已有 opt-in、non-persisting harness，但未记录 exact-version `codex-acp` 或 `claude-agent-acp` provider run |
 | Rollback | `PARTIAL` | 现有 direct `cosh-shell raw cosh-core` path 保留，raw-package routing 已测试；installed-package smoke 仍缺 |
 
 Source 存在不等于用户侧验收。使用临时 executable file 的 profile resolver test 不能证明
@@ -46,7 +48,7 @@ Source 存在不等于用户侧验收。使用临时 executable file 的 profile
 | ID | Criterion | 当前结果 | 必需证明 |
 | --- | --- | --- | --- |
 | MVP-01 | 一个已安装 COSH entrypoint 接受内置 profile、canonical workspace 与 bounded text prompt | `PARTIAL` | Binary integration 与 raw-package routing 通过；installed-package smoke 仍缺 |
-| MVP-02 | 只启动本地已安装 `codex-acp` 或 `claude-agent-acp`；不可能启动原生 Codex/Claude、`npx`、shell、package runner 或 network bootstrap | `PARTIAL` | Runtime resolver 从不 bootstrap package；distribution 与 installed-package proof 仍缺 |
+| MVP-02 | 只启动本地已安装 `codex-acp` 或 `claude-agent-acp`；不可能启动原生 Codex/Claude、`npx`、shell、package runner 或 network bootstrap | `PARTIAL` | Runtime resolver 从不 bootstrap package；显式 installer 固定并校验两个 Adapter package，但 signed/offline distribution 仍缺 |
 | MVP-03 | Profile resolve 固定 exact basename、canonical executable/workspace、fixed args 与 allowlisted environment，且不记录 value | `PARTIAL` | Entrypoint path 的 positive 与 spoof/path/environment test |
 | MVP-04 | Driver 按序执行 ACP v1 initialize、单 session/new 与单 active text prompt | `PARTIAL` | End-to-end Driver fixture 以及 wrong-order/duplicate-prompt negative |
 | MVP-05 | Text update 按接收顺序交付，带有界 local sequence、queue depth 与 byte | `NOT IMPLEMENTED` | Multi-chunk 与 saturation fixture |
@@ -126,6 +128,30 @@ cargo +1.88.0 test --locked --package cosh-gateway \
 # 7 passed
 ```
 
+## Stage 3 Adapter 证据
+
+Source installer 通过 committed lockfile 固定
+`@agentclientprotocol/codex-acp` `1.2.0` 与
+`@agentclientprotocol/claude-agent-acp` `0.66.0`。Installer 只接受显式 absolute
+private prefix，并拒绝 symlink、非当前用户所有、向 group/world 开放或含无关内容的
+non-empty prefix。完成 `npm ci --ignore-scripts` 后，它会校验 package name、version
+与 canonical `bin` target。COSH runtime resolver 永远不能调用 npm。
+
+Fake conformance 验证 initialization、session creation、两个有序 text chunk、prompt
+completion 与唯一 terminal event。Real mode 为 opt-in，要求 piped prompt 与
+`--acknowledge-provider-run`，校验 exact package provenance，并在内存中把 JSONL
+归约为 event count。它不创建 evidence file，也不回显 prompt 或 Agent text。
+
+```bash
+bash src/cosh-ng/tests/test-acp-adapters.sh
+src/cosh-ng/scripts/run-acp-conformance.sh fake \
+  --gateway "$PWD/src/cosh-ng/target/debug/cosh-gateway" \
+  --workspace "$PWD"
+```
+
+这些 check 使用 fake npm 与确定性 fake Agent，不通过网络安装、不调用 provider，
+也不把 MVP-13 从 `NOT RUN` 改为通过。
+
 ## Exit Criteria
 
 ACP MVP 只在以下条件全部成立时接受：
@@ -141,5 +167,5 @@ ACP MVP 只在以下条件全部成立时接受：
 ## 文档验证
 
 双语文档必须通过仓库 docs lint、relative-link check、pairing/parity review 与
-`git diff --check`。Stage 2 不运行 provider、ECS 或真实 Adapter，因此不能把 MVP-13
+`git diff --check`。Stage 3 不运行 provider、ECS 或真实 Adapter，因此不能把 MVP-13
 从 `NOT RUN` 改为通过。

--- a/src/cosh-ng/docs/design/acp-v1-phase-0-2/phase-1/acp-mvp/design.md
+++ b/src/cosh-ng/docs/design/acp-v1-phase-0-2/phase-1/acp-mvp/design.md
@@ -19,14 +19,14 @@ The candidate worktree already provides:
   `session/update`, permission correlation, cancellation frames, and
   fail-closed decoding;
 - built-in `Codex` and `ClaudeCode` profile resolution for the locally
-  installed `codex-acp` and `claude-agent-acp` adapters.
+  installed `codex-acp` and `claude-agent-acp` adapters;
+- an installed local entrypoint, bounded session driver, and deterministic
+  fake-Adapter conformance path.
 
-These are library-level foundations. No installed COSH entrypoint selects a
-profile and drives a complete turn. The current synchronous bridge does not
-provide an independent cancellation control path while its owner is blocked
-reading Agent stdout. Permission responses are correlated ACP wire responses,
-not yet a COSH approval or Capability Broker decision. No real adapter evidence
-has been recorded.
+The remaining acceptance gap is not entrypoint or permission source presence.
+It is installed-package proof, the full failure/race matrix, and a sanitized
+real-Adapter run. Permission responses remain narrower than durable Task
+approval or a complete Capability Broker decision.
 
 ## MVP outcome
 
@@ -61,8 +61,8 @@ The complete MVP profile is deliberately fixed:
 The MVP does not include:
 
 - native ACP support in the Codex or Claude Code binaries;
-- downloading or executing adapters through `npx`, a shell, a package runner,
-  or any network bootstrap;
+- runtime downloading or executing adapters through `npx`, a shell, a package
+  runner, or any network bootstrap;
 - filesystem callbacks, terminal callbacks, rich prompt content, additional
   directories, session load, session resume, or multi-session operation;
 - `allow_always`, `reject_always`, durable trust rules, or policy mutation;
@@ -93,6 +93,30 @@ executable, or change the workspace.
 
 The adapter executables are separate installed adapters. Documentation and UI
 must not claim that the native `codex` or `claude` command implements ACP.
+
+## Adapter distribution and conformance boundary
+
+Adapter installation is an explicit operator/developer step outside the COSH
+runtime. The source helper installs one lockfile-defined bundle into an
+explicit private prefix with package scripts disabled. It verifies the exact
+package name, version, and `bin` target before that path can be selected for
+validation. The runtime still accepts only an exact installed executable path
+or allowlisted `PATH` lookup and has no npm or network code path.
+
+The Stage 3 bundle is fixed:
+
+| Profile | npm package | Version |
+| --- | --- | --- |
+| `codex` | `@agentclientprotocol/codex-acp` | `1.2.0` |
+| `claude-code` | `@agentclientprotocol/claude-agent-acp` | `0.66.0` |
+
+Conformance has two deliberately separate modes. Fake mode constructs a local
+deterministic Adapter and verifies ordered protocol/presentation events without
+credentials or network access. Real mode requires explicit acknowledgement,
+an exact pinned package path, and a prompt supplied through stdin. It reduces
+the JSONL stream to counts in memory and never writes or echoes prompt/Agent
+text. A real mode result is evidence only for the selected profile and exact
+candidate revision; it cannot be inferred from fake mode.
 
 ## Local entrypoint
 

--- a/src/cosh-ng/docs/design/acp-v1-phase-0-2/phase-1/acp-mvp/design_zh.md
+++ b/src/cosh-ng/docs/design/acp-v1-phase-0-2/phase-1/acp-mvp/design_zh.md
@@ -18,12 +18,12 @@
   `session/update`、permission correlation、cancellation frame 与 fail-closed
   decode；
 - 面向本地已安装 `codex-acp` 与 `claude-agent-acp` Adapter 的内置 `Codex`
-  和 `ClaudeCode` profile resolver。
+  和 `ClaudeCode` profile resolver；
+- 已安装 local entrypoint、有界 Session Driver 与确定性 fake-Adapter conformance path。
 
-这些仍是 library-level foundation。当前没有已安装的 COSH entrypoint 选择 profile
-并驱动完整 turn。同步 Bridge 的 owner 阻塞等待 Agent stdout 时，尚无独立 cancellation
-control path。Permission response 是有关联的 ACP wire response，尚不是 COSH approval
-或 Capability Broker decision。也没有记录真实 Adapter 证据。
+剩余验收缺口不再是 entrypoint 或 permission source 是否存在，而是
+installed-package proof、完整 failure/race matrix 与脱敏真实 Adapter run。Permission
+response 的范围仍小于持久 Task approval 或完整 Capability Broker decision。
 
 ## MVP 结果
 
@@ -56,7 +56,7 @@ MVP profile 固定如下：
 MVP 不包括：
 
 - Codex 或 Claude Code binary 原生实现 ACP；
-- 通过 `npx`、shell、package runner 或任何 network bootstrap 下载或执行 Adapter；
+- Runtime 通过 `npx`、shell、package runner 或任何 network bootstrap 下载或执行 Adapter；
 - filesystem callback、terminal callback、rich prompt content、additional directory、
   session load、session resume 或 multi-session；
 - `allow_always`、`reject_always`、持久 trust rule 或 policy mutation；
@@ -82,6 +82,27 @@ output 均不能增加 process argument、替换 executable 或改变 workspace�
 
 这些 executable 是单独安装的 Adapter。文档与 UI 不得声称原生 `codex` 或 `claude`
 command 已实现 ACP。
+
+## Adapter Distribution 与 Conformance 边界
+
+Adapter 安装是 COSH runtime 之外的显式 operator/developer 操作。Source helper 把一个由
+lockfile 定义的 bundle 安装到显式 private prefix，并禁用 package script。该 helper
+会校验准确 package name、version 与 `bin` target，之后该路径才可用于 validation。
+Runtime 仍只接受 exact installed executable path 或 allowlisted `PATH` lookup，不存在
+npm 或 network code path。
+
+Stage 3 bundle 固定如下：
+
+| Profile | npm package | Version |
+| --- | --- | --- |
+| `codex` | `@agentclientprotocol/codex-acp` | `1.2.0` |
+| `claude-code` | `@agentclientprotocol/claude-agent-acp` | `0.66.0` |
+
+Conformance 明确分为两种模式。Fake mode 构造本地确定性 Adapter，在没有 credential 或
+network access 的情况下验证有序 protocol/presentation event。Real mode 要求显式确认、
+exact pinned package path，以及通过 stdin 提供的 prompt。它在内存中把 JSONL stream
+归约为 count，不写入或回显 prompt/Agent text。Real mode 结果只证明所选 profile 与
+精确 candidate revision，不能从 fake mode 推断。
 
 ## Local Entrypoint
 

--- a/src/cosh-ng/scripts/acp-adapters/package-lock.json
+++ b/src/cosh-ng/scripts/acp-adapters/package-lock.json
@@ -1,0 +1,1847 @@
+{
+  "name": "cosh-ng-acp-adapter-validation",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cosh-ng-acp-adapter-validation",
+      "version": "1.0.0",
+      "dependencies": {
+        "@agentclientprotocol/claude-agent-acp": "0.66.0",
+        "@agentclientprotocol/codex-acp": "1.2.0"
+      }
+    },
+    "node_modules/@agentclientprotocol/claude-agent-acp": {
+      "version": "0.66.0",
+      "resolved": "https://registry.npmmirror.com/@agentclientprotocol/claude-agent-acp/-/claude-agent-acp-0.66.0.tgz",
+      "integrity": "sha512-BwalxKsxZzHZGEs+X9hV3biErLE7PHWoao2hmyP3QBWXxvMHbc1F1tzDE95ZA47Fle+KBYf2gKpgy1MJ+ZmVlw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@agentclientprotocol/sdk": "1.3.0",
+        "@anthropic-ai/claude-agent-sdk": "0.3.220",
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "bin": {
+        "claude-agent-acp": "dist/index.js"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/@agentclientprotocol/codex-acp": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/@agentclientprotocol/codex-acp/-/codex-acp-1.2.0.tgz",
+      "integrity": "sha512-nj23pM4OfaCOB5Du5rsSq0kcyki5H8D5ql96+AwIv7lnu0YEKj9R2YDsxbOKzwLlt+5QD6s0mn4Grkm7SSAUUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@agentclientprotocol/sdk": "^1.3.0",
+        "@openai/codex": "^0.147.0",
+        "diff": "^9.0.0",
+        "open": "^11.0.0",
+        "vscode-jsonrpc": "^9.0.1",
+        "zod": "^4.0.0"
+      },
+      "bin": {
+        "codex-acp": "dist/index.js"
+      }
+    },
+    "node_modules/@agentclientprotocol/sdk": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmmirror.com/@agentclientprotocol/sdk/-/sdk-1.3.0.tgz",
+      "integrity": "sha512-i3h/efaeuMUFAO1HSfo97QZQnnvMd7wWBYtBsdL6UMZg3a78sk3Ffya5Xu7C7tYsXomXoDXJBAzQF2PcFKAhIQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk": {
+      "version": "0.3.220",
+      "resolved": "https://registry.npmmirror.com/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.220.tgz",
+      "integrity": "sha512-glc7SdwPkOkLw8oxwLo9PKTdLJGqW/PIR4urWXFoRtX9YllwozsEVc5Tc1+EvLSkfrsxPJqQWqOgpjUOQXf1oA==",
+      "license": "SEE LICENSE IN README.md",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.220",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.220"
+      },
+      "peerDependencies": {
+        "@anthropic-ai/sdk": ">=0.93.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
+      "version": "0.3.220",
+      "resolved": "https://registry.npmmirror.com/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.220.tgz",
+      "integrity": "sha512-7VxlbEosK7DODiOnsjoVd0DSJzbnaPrM2jelMHI0y8zx1UnLS3WC6EFUXbvy74F2sXqEznh2tzn7EKWInaRN6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
+      "version": "0.3.220",
+      "resolved": "https://registry.npmmirror.com/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.220.tgz",
+      "integrity": "sha512-X9RwDsSmbF6ultKZroaip+DL8WRgC64gHbrAwrRlAFSPNZV7zmJyP2ur8rW7KrxqmtuehdMMkw8+SAC/6hD2PA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
+      "version": "0.3.220",
+      "resolved": "https://registry.npmmirror.com/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.220.tgz",
+      "integrity": "sha512-WkROPwWskqhKR9XgnmseHQ6rLi9zM9qt57IWoToIjL/eXOqDWipp7JXZ1L5ud+LrA42dunHPZfBwD/vXZ+A7LA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
+      "version": "0.3.220",
+      "resolved": "https://registry.npmmirror.com/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.220.tgz",
+      "integrity": "sha512-OHoZOZ8Cf2TBr6oXIXPwyvUxj9jrq2w8E4poA8dMpacXszcPSPiCQCMuuOh4aWJzfeJE1+TtWxhKMVb2csXyZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
+      "version": "0.3.220",
+      "resolved": "https://registry.npmmirror.com/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.220.tgz",
+      "integrity": "sha512-tkTJFnpR9VifvWX2fmkCAPkT6+8Wk/gVu8B5jsVekKZPiZoWRHmMXO30BnZn+f0TZhgYP+82PSX3S8crH1kn+w==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
+      "version": "0.3.220",
+      "resolved": "https://registry.npmmirror.com/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.220.tgz",
+      "integrity": "sha512-K+FWj+LcGhC1Z7wqeWoLxm1iemcba5xKpLLFVwYm4V6HyMx3ruYd/2r2TiQtjT+JWeNFWIys0ScHiItR6vWAiA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
+      "version": "0.3.220",
+      "resolved": "https://registry.npmmirror.com/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.220.tgz",
+      "integrity": "sha512-rIwgq0UwQExWl6KrHUyC4w5KwpL9l6nd95aUTx6RitexaAuEw//xtfTVLnuE4hDDQZFkzEwpdKc3nxDWoGcUbA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
+      "version": "0.3.220",
+      "resolved": "https://registry.npmmirror.com/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.220.tgz",
+      "integrity": "sha512-MuOuXhbr66HlGaWXD2f3w0k2PsvmnbkwcUZ0dAe2poFLdl72GC2dapwwOBefxm9QmoNqk9+jmv/dSKGOVWyvLw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.116.0",
+      "resolved": "https://registry.npmmirror.com/@anthropic-ai/sdk/-/sdk-0.116.0.tgz",
+      "integrity": "sha512-4UEapYQ+epLEMsAuLZDvW8ExVSOtHD8a7zTyLzhw0H9RXJ1eilPgmqhjwgcdg22diwx13spw6fJ4rONZ+bS7Ww==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmmirror.com/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/@hono/node-server/-/node-server-2.1.0.tgz",
+      "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmmirror.com/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@openai/codex": {
+      "version": "0.147.0",
+      "resolved": "https://registry.npmmirror.com/@openai/codex/-/codex-0.147.0.tgz",
+      "integrity": "sha512-EQLEXecAG2ptxI7UpBMo2TR/ga5596/c/OsYF/0LoUDh5JANZ7IoGqlzBEWbuEVQ76JePIbtTW/ihCkp1a7Z3w==",
+      "license": "Apache-2.0",
+      "bin": {
+        "codex": "bin/codex.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.147.0-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.147.0-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.147.0-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.147.0-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.147.0-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.147.0-win32-x64"
+      }
+    },
+    "node_modules/@openai/codex-darwin-arm64": {
+      "name": "@openai/codex",
+      "version": "0.147.0-darwin-arm64",
+      "resolved": "https://registry.npmmirror.com/@openai/codex/-/codex-0.147.0-darwin-arm64.tgz",
+      "integrity": "sha512-BEUVkiOW7kLcRyrMLfAr/h9wF8sRVJyZDy6OHtVn6QGDXiv3BvAZVTY1Pu9xF7KdIdkYXbp4uayN0aDQQaAUJw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-darwin-x64": {
+      "name": "@openai/codex",
+      "version": "0.147.0-darwin-x64",
+      "resolved": "https://registry.npmmirror.com/@openai/codex/-/codex-0.147.0-darwin-x64.tgz",
+      "integrity": "sha512-Tb8McE5SvJIH0Vs5R6sq7u+quiC931yan2KOOl6km1OdZ82+Wi7eF5XrSFPs5CF7xCgoIK4Vs+byMbT5hN+ZUw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-linux-arm64": {
+      "name": "@openai/codex",
+      "version": "0.147.0-linux-arm64",
+      "resolved": "https://registry.npmmirror.com/@openai/codex/-/codex-0.147.0-linux-arm64.tgz",
+      "integrity": "sha512-SLC1JXw2TYfr/c3HhrJubyyLelq7vTOLWVmiThFA+z0+WgzCPmaseJ/kzDD3Gge/TO7fCnnj7UcPmC0d2c8XAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-linux-x64": {
+      "name": "@openai/codex",
+      "version": "0.147.0-linux-x64",
+      "resolved": "https://registry.npmmirror.com/@openai/codex/-/codex-0.147.0-linux-x64.tgz",
+      "integrity": "sha512-0W9MBxPpWW0cSkNqrTDN2jR7rzzT7oNMhQY5446lT2Lw5cz5yhDTck4Va9rjkQEm+HlFzP/dmEMSZbXfJsINmw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-win32-arm64": {
+      "name": "@openai/codex",
+      "version": "0.147.0-win32-arm64",
+      "resolved": "https://registry.npmmirror.com/@openai/codex/-/codex-0.147.0-win32-arm64.tgz",
+      "integrity": "sha512-e2ZstJ8zT8Rm1nvR7CUVO+Gr3cTChE41+VfOzGhynzDXEoW0wfbjUQbc2bWbh1arG94LMm4y3dqBtUIbSrfeGA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-win32-x64": {
+      "name": "@openai/codex",
+      "version": "0.147.0-win32-x64",
+      "resolved": "https://registry.npmmirror.com/@openai/codex/-/codex-0.147.0-win32-x64.tgz",
+      "integrity": "sha512-oT7Ss5fAPf2fiWE9QNURqZcQGAAawSVxmIUdgPzckq4KFZAM+pRz9JbM4Rr498CjtbNgTOjWvDJ+DXvIBSfOPA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmmirror.com/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmmirror.com/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmmirror.com/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmmirror.com/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmmirror.com/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmmirror.com/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmmirror.com/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmmirror.com/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmmirror.com/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmmirror.com/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmmirror.com/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmmirror.com/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmmirror.com/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmmirror.com/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmmirror.com/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmmirror.com/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmmirror.com/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmmirror.com/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmmirror.com/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmmirror.com/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+      "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmmirror.com/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.2",
+      "resolved": "https://registry.npmmirror.com/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmmirror.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmmirror.com/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense",
+      "peer": true
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmmirror.com/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmmirror.com/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmmirror.com/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmmirror.com/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmmirror.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmmirror.com/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.13.1",
+      "resolved": "https://registry.npmmirror.com/hono/-/hono-4.13.1.tgz",
+      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmmirror.com/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmmirror.com/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/ip-address": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmmirror.com/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmmirror.com/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-in-ssh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+      "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmmirror.com/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/jose": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmmirror.com/jose/-/jose-6.2.8.tgz",
+      "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmmirror.com/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmmirror.com/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause",
+      "peer": true
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmmirror.com/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmmirror.com/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmmirror.com/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmmirror.com/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmmirror.com/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmmirror.com/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmmirror.com/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/open": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmmirror.com/open/-/open-11.0.0.tgz",
+      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.4.0",
+        "define-lazy-prop": "^3.0.0",
+        "is-in-ssh": "^1.0.0",
+        "is-inside-container": "^1.0.0",
+        "powershell-utils": "^0.1.0",
+        "wsl-utils": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmmirror.com/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmmirror.com/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmmirror.com/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmmirror.com/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/powershell-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmmirror.com/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmmirror.com/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmmirror.com/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmmirror.com/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmmirror.com/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmmirror.com/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmmirror.com/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmmirror.com/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmmirror.com/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmmirror.com/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmmirror.com/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmmirror.com/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmmirror.com/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmmirror.com/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmmirror.com/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmmirror.com/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmmirror.com/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmmirror.com/vscode-jsonrpc/-/vscode-jsonrpc-9.0.1.tgz",
+      "integrity": "sha512-rfuA6T75H6m5EkbhtEPzre9pT0HPcDI2MMy4+nPFIBks5J8JBAUHD4tRYSgaBOijIEC7SRkC1kKyXTLqbmh9jw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmmirror.com/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmmirror.com/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmmirror.com/wsl-utils/-/wsl-utils-0.3.1.tgz",
+      "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0",
+        "powershell-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmmirror.com/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmmirror.com/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peer": true,
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/src/cosh-ng/scripts/acp-adapters/package.json
+++ b/src/cosh-ng/scripts/acp-adapters/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "cosh-ng-acp-adapter-validation",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Pinned official ACP adapters used only by cosh-ng conformance validation",
+  "dependencies": {
+    "@agentclientprotocol/claude-agent-acp": "0.66.0",
+    "@agentclientprotocol/codex-acp": "1.2.0"
+  }
+}

--- a/src/cosh-ng/scripts/install-acp-adapters.sh
+++ b/src/cosh-ng/scripts/install-acp-adapters.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly INSTALL_MARKER=".cosh-acp-adapters"
+readonly CODEX_PACKAGE="@agentclientprotocol/codex-acp"
+readonly CODEX_VERSION="1.2.0"
+readonly CLAUDE_PACKAGE="@agentclientprotocol/claude-agent-acp"
+readonly CLAUDE_VERSION="0.66.0"
+
+usage() {
+  echo "usage: $0 --prefix ABSOLUTE_PRIVATE_DIRECTORY" >&2
+}
+
+prefix=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --prefix)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      prefix="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+[[ "$prefix" = /* && "$prefix" != / ]] || {
+  echo "--prefix must be an absolute non-root directory" >&2
+  exit 2
+}
+command -v npm >/dev/null 2>&1 || { echo "npm is required" >&2; exit 1; }
+command -v node >/dev/null 2>&1 || { echo "node is required" >&2; exit 1; }
+
+prepare_prefix() {
+  local parent
+  parent=$(dirname -- "$prefix")
+  [[ -d "$parent" && ! -L "$parent" ]] || {
+    echo "adapter prefix parent must be an existing non-symlink directory" >&2
+    exit 2
+  }
+  [[ "$(readlink -f -- "$parent")/$(basename -- "$prefix")" == "$prefix" ]] || {
+    echo "adapter prefix must be normalized and have no symlink ancestors" >&2
+    exit 2
+  }
+
+  if [[ -e "$prefix" || -L "$prefix" ]]; then
+    [[ -d "$prefix" && ! -L "$prefix" ]] || {
+      echo "adapter prefix must be a non-symlink directory" >&2
+      exit 2
+    }
+    [[ "$(stat -c '%u' -- "$prefix")" == "$(id -u)" ]] || {
+      echo "adapter prefix must be owned by the current user" >&2
+      exit 2
+    }
+    (( (8#$(stat -c '%a' -- "$prefix") & 8#077) == 0 )) || {
+      echo "adapter prefix must not grant group or other permissions" >&2
+      exit 2
+    }
+    if [[ -n "$(find "$prefix" -mindepth 1 -maxdepth 1 -print -quit)" &&
+          ! -f "$prefix/$INSTALL_MARKER" ]]; then
+      echo "non-empty adapter prefix is not managed by COSH" >&2
+      exit 2
+    fi
+  else
+    mkdir -m 0700 -- "$prefix"
+  fi
+}
+
+verify_package_bin() {
+  local command_name="$1"
+  local package_name="$2"
+  local expected_version="$3"
+  local candidate="$prefix/node_modules/.bin/$command_name"
+  local package_dir="$prefix/node_modules/$package_name"
+
+  [[ -x "$candidate" ]] || {
+    echo "missing installed adapter: $command_name" >&2
+    exit 1
+  }
+  [[ -d "$package_dir" && ! -L "$package_dir" ]] || {
+    echo "missing installed package: $package_name" >&2
+    exit 1
+  }
+
+  node - "$candidate" "$package_dir" "$package_name" "$expected_version" "$command_name" <<'NODE'
+const fs = require("fs");
+const path = require("path");
+
+const [candidate, packageDir, expectedName, expectedVersion, commandName] =
+  process.argv.slice(2);
+const prefixModules = path.dirname(path.dirname(packageDir));
+const packageJsonPath = path.join(packageDir, "package.json");
+const manifest = JSON.parse(fs.readFileSync(packageJsonPath, "utf8"));
+const bin = typeof manifest.bin === "string" ? manifest.bin : manifest.bin?.[commandName];
+
+if (manifest.name !== expectedName || manifest.version !== expectedVersion) {
+  throw new Error(`unexpected package identity for ${commandName}`);
+}
+if (typeof bin !== "string" || path.isAbsolute(bin)) {
+  throw new Error(`invalid package bin mapping for ${commandName}`);
+}
+
+const canonicalCandidate = fs.realpathSync(candidate);
+const canonicalTarget = fs.realpathSync(path.join(packageDir, bin));
+const canonicalModules = fs.realpathSync(prefixModules) + path.sep;
+if (canonicalCandidate !== canonicalTarget || !canonicalTarget.startsWith(canonicalModules)) {
+  throw new Error(`adapter provenance mismatch for ${commandName}`);
+}
+NODE
+}
+
+prepare_prefix
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)
+manifest_dir="$script_dir/acp-adapters"
+install -m 0600 "$manifest_dir/package.json" "$prefix/package.json"
+install -m 0600 "$manifest_dir/package-lock.json" "$prefix/package-lock.json"
+printf '%s\n' "cosh-ng-acp-adapters-v1" >"$prefix/$INSTALL_MARKER"
+chmod 0600 "$prefix/$INSTALL_MARKER"
+
+# This explicit developer operation is the only network-capable package step.
+# COSH runtime resolution never invokes npm, npx, a shell, or a downloader.
+npm ci --prefix "$prefix" --omit=dev --ignore-scripts --no-audit --no-fund
+
+verify_package_bin codex-acp "$CODEX_PACKAGE" "$CODEX_VERSION"
+verify_package_bin claude-agent-acp "$CLAUDE_PACKAGE" "$CLAUDE_VERSION"
+
+printf 'Installed pinned ACP adapter bundle below %s\n' "$prefix"
+printf '  codex-acp: %s\n' "$CODEX_VERSION"
+printf '  claude-agent-acp: %s\n' "$CLAUDE_VERSION"
+printf 'Pass an exact adapter path to cosh-gateway; do not add the bundle to global PATH.\n'

--- a/src/cosh-ng/scripts/run-acp-conformance.sh
+++ b/src/cosh-ng/scripts/run-acp-conformance.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly CODEX_PACKAGE="@agentclientprotocol/codex-acp"
+readonly CODEX_VERSION="1.2.0"
+readonly CLAUDE_PACKAGE="@agentclientprotocol/claude-agent-acp"
+readonly CLAUDE_VERSION="0.66.0"
+
+usage() {
+  cat >&2 <<'USAGE'
+usage:
+  run-acp-conformance.sh fake --gateway ABSOLUTE_BINARY --workspace ABSOLUTE_DIRECTORY
+  run-acp-conformance.sh real --gateway ABSOLUTE_BINARY --workspace ABSOLUTE_DIRECTORY \
+    --profile codex|claude-code --adapter ABSOLUTE_BINARY --acknowledge-provider-run
+
+The real run reads exactly one prompt from stdin. It validates JSONL in memory
+and emits only event counts; prompts and Agent text are never written to an
+evidence file or echoed by this harness.
+USAGE
+}
+
+[[ $# -ge 1 ]] || { usage; exit 2; }
+mode="$1"
+shift
+
+gateway=""
+workspace=""
+profile=""
+adapter=""
+acknowledge_provider_run=false
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --gateway)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      gateway="$2"
+      shift 2
+      ;;
+    --workspace)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      workspace="$2"
+      shift 2
+      ;;
+    --profile)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      profile="$2"
+      shift 2
+      ;;
+    --adapter)
+      [[ $# -ge 2 ]] || { usage; exit 2; }
+      adapter="$2"
+      shift 2
+      ;;
+    --acknowledge-provider-run)
+      acknowledge_provider_run=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+[[ "$mode" == fake || "$mode" == real ]] || { usage; exit 2; }
+[[ "$gateway" = /* && -f "$gateway" && -x "$gateway" ]] || {
+  echo "--gateway must be an absolute executable file" >&2
+  exit 2
+}
+[[ "$workspace" = /* && -d "$workspace" ]] || {
+  echo "--workspace must be an absolute existing directory" >&2
+  exit 2
+}
+command -v python3 >/dev/null 2>&1 || { echo "python3 is required" >&2; exit 1; }
+
+validate_events() {
+  local scenario="$1"
+  python3 -c '
+import json
+import sys
+
+scenario = sys.argv[1]
+events = []
+for line in sys.stdin:
+    record = json.loads(line)
+    event = record.get("event")
+    if not isinstance(event, str):
+        raise SystemExit("COSH emitted a JSONL record without an event")
+    if event == "error":
+        raise SystemExit("COSH emitted an error event")
+    events.append(event)
+
+required = {
+    "doctor": ["initialized", "session_opened", "terminal", "doctor_ok"],
+    "run": ["initialized", "session_opened", "session_update",
+            "prompt_finished", "terminal"],
+}[scenario]
+cursor = 0
+for expected in required:
+    try:
+        cursor = events.index(expected, cursor) + 1
+    except ValueError:
+        raise SystemExit(f"missing ordered event {expected}") from None
+if events.count("terminal") != 1:
+    raise SystemExit("expected exactly one terminal event")
+if scenario == "run" and events.count("session_update") < 2:
+    raise SystemExit("expected at least two streamed text updates")
+
+counts = {name: events.count(name) for name in required}
+print(json.dumps({"scenario": scenario, "status": "pass", "events": counts},
+                 sort_keys=True, separators=(",", ":")))
+' "$scenario"
+}
+
+run_doctor() {
+  local selected_profile="$1"
+  local selected_adapter="$2"
+  "$gateway" doctor \
+    --profile "$selected_profile" \
+    --adapter "$selected_adapter" \
+    --workspace "$workspace" \
+    --output jsonl 2>/dev/null | validate_events doctor
+}
+
+run_prompt() {
+  local selected_profile="$1"
+  local selected_adapter="$2"
+  "$gateway" run \
+    --profile "$selected_profile" \
+    --adapter "$selected_adapter" \
+    --workspace "$workspace" \
+    --output jsonl 2>/dev/null | validate_events run
+}
+
+verify_real_adapter() {
+  local selected_profile="$1"
+  local candidate="$2"
+  local package_name expected_version command_name
+  case "$selected_profile" in
+    codex)
+      package_name="$CODEX_PACKAGE"
+      expected_version="$CODEX_VERSION"
+      command_name="codex-acp"
+      ;;
+    claude-code)
+      package_name="$CLAUDE_PACKAGE"
+      expected_version="$CLAUDE_VERSION"
+      command_name="claude-agent-acp"
+      ;;
+    *)
+      echo "real mode requires --profile codex or claude-code" >&2
+      exit 2
+      ;;
+  esac
+  [[ "$candidate" = /* && "$(basename -- "$candidate")" == "$command_name" ]] || {
+    echo "--adapter must be an absolute profile-matching executable" >&2
+    exit 2
+  }
+  [[ -x "$candidate" ]] || { echo "adapter is not executable" >&2; exit 2; }
+
+  node - "$candidate" "$package_name" "$expected_version" "$command_name" <<'NODE'
+const fs = require("fs");
+const path = require("path");
+
+const [candidate, expectedName, expectedVersion, commandName] = process.argv.slice(2);
+const target = fs.realpathSync(candidate);
+const marker = `${path.sep}node_modules${path.sep}${expectedName}${path.sep}`;
+const markerIndex = target.lastIndexOf(marker);
+if (markerIndex < 0) throw new Error("adapter is not from the pinned npm package");
+const packageDir = target.slice(0, markerIndex + marker.length - 1);
+const manifest = JSON.parse(fs.readFileSync(path.join(packageDir, "package.json"), "utf8"));
+const bin = typeof manifest.bin === "string" ? manifest.bin : manifest.bin?.[commandName];
+if (manifest.name !== expectedName || manifest.version !== expectedVersion ||
+    typeof bin !== "string" || fs.realpathSync(path.join(packageDir, bin)) !== target) {
+  throw new Error("adapter package provenance mismatch");
+}
+NODE
+}
+
+if [[ "$mode" == fake ]]; then
+  [[ -z "$profile" && -z "$adapter" && "$acknowledge_provider_run" == false ]] || {
+    echo "fake mode does not accept real-adapter options" >&2
+    exit 2
+  }
+  temp_root=$(mktemp -d)
+  trap 'rm -rf -- "$temp_root"' EXIT
+  fake_adapter="$temp_root/codex-acp"
+  python_path=$(command -v python3)
+  printf '#!%s\n' "$python_path" >"$fake_adapter"
+  cat >>"$fake_adapter" <<'PY'
+import json
+import sys
+
+session_id = "cosh-conformance-session"
+for line in sys.stdin:
+    request = json.loads(line)
+    method = request.get("method")
+    request_id = request.get("id")
+    if method == "initialize":
+        result = {
+            "protocolVersion": 1,
+            "agentCapabilities": {},
+            "agentInfo": {"name": "cosh-conformance-fake", "version": "1.0"},
+        }
+        print(json.dumps({"jsonrpc": "2.0", "id": request_id, "result": result}), flush=True)
+    elif method == "session/new":
+        print(json.dumps({"jsonrpc": "2.0", "id": request_id,
+                          "result": {"sessionId": session_id}}), flush=True)
+    elif method == "session/prompt":
+        content = request.get("params", {}).get("prompt", [])
+        if len(content) != 1 or content[0].get("type") != "text" or not content[0].get("text"):
+            raise SystemExit("expected one non-empty text prompt")
+        for text in ("fake-first", "fake-second"):
+            update = {"sessionUpdate": "agent_message_chunk",
+                      "content": {"type": "text", "text": text}}
+            print(json.dumps({"jsonrpc": "2.0", "method": "session/update",
+                              "params": {"sessionId": session_id, "update": update}}), flush=True)
+        print(json.dumps({"jsonrpc": "2.0", "id": request_id,
+                          "result": {"stopReason": "end_turn"}}), flush=True)
+    else:
+        raise SystemExit(f"unexpected ACP method: {method}")
+PY
+  chmod 0700 "$fake_adapter"
+
+  run_doctor codex "$fake_adapter"
+  printf '%s\n' "deterministic fake prompt" | run_prompt codex "$fake_adapter"
+  printf '%s\n' '{"profile":"fake","status":"pass","raw_output_persisted":false}'
+  exit 0
+fi
+
+[[ "$acknowledge_provider_run" == true ]] || {
+  echo "real mode requires --acknowledge-provider-run" >&2
+  exit 2
+}
+[[ ! -t 0 ]] || {
+  echo "pipe one explicit prompt to stdin; interactive prompt capture is disabled" >&2
+  exit 2
+}
+command -v node >/dev/null 2>&1 || { echo "node is required" >&2; exit 1; }
+verify_real_adapter "$profile" "$adapter"
+run_doctor "$profile" "$adapter"
+run_prompt "$profile" "$adapter"
+printf '%s\n' \
+  "{\"profile\":\"$profile\",\"status\":\"pass\",\"raw_output_persisted\":false}"

--- a/src/cosh-ng/tests/test-acp-adapters.sh
+++ b/src/cosh-ng/tests/test-acp-adapters.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+component_root=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd -P)
+installer="$component_root/scripts/install-acp-adapters.sh"
+conformance="$component_root/scripts/run-acp-conformance.sh"
+temp_root=$(mktemp -d)
+trap 'rm -rf -- "$temp_root"' EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+expect_exit() {
+  local expected="$1"
+  shift
+  set +e
+  "$@" >/dev/null 2>&1
+  local actual=$?
+  set -e
+  [[ "$actual" == "$expected" ]] || fail "expected exit $expected, got $actual: $*"
+}
+
+fake_bin="$temp_root/bin"
+mkdir -m 0700 "$fake_bin"
+fake_npm="$fake_bin/npm"
+cat >"$fake_npm" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+[[ "${1:-}" == ci ]] || exit 90
+shift
+prefix=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --prefix)
+      prefix="$2"
+      shift 2
+      ;;
+    --omit=dev|--ignore-scripts|--no-audit|--no-fund)
+      shift
+      ;;
+    *) exit 91 ;;
+  esac
+done
+[[ -n "$prefix" ]] || exit 92
+
+create_package() {
+  local scope="$1"
+  local package="$2"
+  local version="$3"
+  local command_name="$4"
+  local package_dir="$prefix/node_modules/$scope/$package"
+  mkdir -p "$package_dir/dist" "$prefix/node_modules/.bin"
+  cat >"$package_dir/package.json" <<JSON
+{"name":"$scope/$package","version":"$version","bin":{"$command_name":"dist/index.js"}}
+JSON
+  cat >"$package_dir/dist/index.js" <<'JS'
+#!/usr/bin/env node
+process.exit(0);
+JS
+  chmod 0755 "$package_dir/dist/index.js"
+  ln -s "../$scope/$package/dist/index.js" "$prefix/node_modules/.bin/$command_name"
+}
+
+codex_version="1.2.0"
+[[ "${FAKE_BAD_CODEX_VERSION:-0}" == 1 ]] && codex_version="9.9.9"
+create_package @agentclientprotocol codex-acp "$codex_version" codex-acp
+create_package @agentclientprotocol claude-agent-acp 0.66.0 claude-agent-acp
+SH
+chmod 0700 "$fake_npm"
+
+expect_exit 2 "$installer" --prefix relative
+expect_exit 2 "$installer" --prefix /
+
+public_prefix="$temp_root/public"
+mkdir -m 0755 "$public_prefix"
+expect_exit 2 env PATH="$fake_bin:$PATH" "$installer" --prefix "$public_prefix"
+
+unmanaged_prefix="$temp_root/unmanaged"
+mkdir -m 0700 "$unmanaged_prefix"
+touch "$unmanaged_prefix/unrelated"
+expect_exit 2 env PATH="$fake_bin:$PATH" "$installer" --prefix "$unmanaged_prefix"
+
+managed_prefix="$temp_root/managed"
+env PATH="$fake_bin:$PATH" "$installer" --prefix "$managed_prefix" >/dev/null
+[[ "$(stat -c '%a' "$managed_prefix")" == 700 ]] || fail "managed prefix is not private"
+[[ -f "$managed_prefix/.cosh-acp-adapters" ]] || fail "installation marker is missing"
+[[ -x "$managed_prefix/node_modules/.bin/codex-acp" ]] || fail "codex adapter is missing"
+[[ -x "$managed_prefix/node_modules/.bin/claude-agent-acp" ]] || fail "claude adapter is missing"
+
+bad_prefix="$temp_root/bad-version"
+expect_exit 1 env PATH="$fake_bin:$PATH" FAKE_BAD_CODEX_VERSION=1 \
+  "$installer" --prefix "$bad_prefix"
+
+workspace="$temp_root/workspace"
+mkdir -m 0700 "$workspace"
+gateway_stub="$temp_root/cosh-gateway"
+cat >"$gateway_stub" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+case "$1" in
+  doctor)
+    printf '%s\n' \
+      '{"event":"initialized"}' \
+      '{"event":"session_opened"}' \
+      '{"event":"terminal"}' \
+      '{"event":"doctor_ok"}'
+    ;;
+  run)
+    cat >/dev/null
+    printf '%s\n' \
+      '{"event":"initialized"}' \
+      '{"event":"session_opened"}' \
+      '{"event":"session_update","text":"never echoed"}' \
+      '{"event":"session_update","text":"never persisted"}' \
+      '{"event":"prompt_finished"}' \
+      '{"event":"terminal"}'
+    ;;
+  *) exit 93 ;;
+esac
+SH
+chmod 0700 "$gateway_stub"
+expect_exit 2 "$conformance" real \
+  --gateway "$gateway_stub" \
+  --workspace "$workspace" \
+  --profile codex \
+  --adapter "$managed_prefix/node_modules/.bin/codex-acp"
+printf '%s\n' 'private prompt' | "$conformance" real \
+  --gateway "$gateway_stub" \
+  --workspace "$workspace" \
+  --profile codex \
+  --adapter "$managed_prefix/node_modules/.bin/codex-acp" \
+  --acknowledge-provider-run >/dev/null
+
+if [[ -n "${COSH_GATEWAY_BIN:-}" ]]; then
+  "$conformance" fake \
+    --gateway "$COSH_GATEWAY_BIN" \
+    --workspace "$workspace" >/dev/null
+fi
+
+echo "ACP adapter installer tests: PASS"


### PR DESCRIPTION
## Why

The ACP entrypoint needs reproducible adapter provenance and a reviewable path
from deterministic fixtures to an explicit real-provider run.

## What changed

- Pin Codex ACP 1.2.0 and Claude Agent ACP 0.66.0 with an exact lockfile.
- Install only into an explicit private managed prefix and verify package bins.
- Add fake and opt-in real conformance modes with sanitized count output.

## Related issue

no-issue: Stage 3 implementation from the audited ACP plan

## User / Agent impact

Developers can install exact adapters into an isolated prefix and validate them
without adding package runners to the COSH runtime path.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed
- [x] Privileged or security-sensitive behavior changed

The installer is an explicit source-tree operation. Runtime resolution remains
offline and fixed-profile. Real-provider mode requires acknowledgement.

## Validation

- isolated fake-npm installer and provenance tests
- fake ACP conformance against a clean Rust 1.88.0 gateway build
- shell syntax, lockfile pin, documentation, and diff checks

Network installation and real provider execution were intentionally not run;
MVP-13 remains NOT RUN for local user validation.

## Documentation and rollback

Updated bilingual MVP design and acceptance evidence. Revert this single commit
to remove the installer and harness.