### PR TITLE
feat(cosh-ng): [gateway] persist ACP ledger

### DIFF
--- a/src/cosh-ng/crates/cosh-gateway/src/storage.rs
+++ b/src/cosh-ng/crates/cosh-gateway/src/storage.rs
@@ -3,10 +3,17 @@
 //! The store owns one write connection and commits task events, projections,
 //! command receipts, and Outbox intents in one immediate transaction.
 
+mod ledger;
 mod schema;
 mod sqlite;
 mod task_store;
 
+pub use ledger::{
+    ApprovalRecord, ApprovalResolution, ApprovalState, ExecutionClaim, ExecutionCompletion,
+    ExecutionRecord, ExecutionState, LeaseClaim, LeaseCommand, LedgerCommand, LedgerOutcome,
+    PermitRecord, PermitState, RecoveryReport, RunLeaseRecord, RuntimeBindingRecord,
+    RuntimeBindingState,
+};
 pub use sqlite::SqliteTaskStore;
 pub use task_store::{CommitOutcome, CommitReceipt, OutboxIntent, TaskCommit};
 
@@ -50,6 +57,26 @@ pub enum StoreError {
         /// Revision supplied by the command.
         expected: u64,
         /// Current durable revision.
+        actual: u64,
+    },
+    /// A durable ledger entity does not exist.
+    #[error("Gateway ledger entity not found: {entity}")]
+    LedgerNotFound {
+        /// Stable entity category and identifier safe for diagnostics.
+        entity: String,
+    },
+    /// A durable ledger transition violates a binding or lifecycle invariant.
+    #[error("Gateway ledger conflict: {message}")]
+    LedgerConflict {
+        /// Bounded developer-oriented reason.
+        message: String,
+    },
+    /// Runtime output belongs to a stale process generation.
+    #[error("runtime generation fenced: expected {expected}, found {actual}")]
+    GenerationFenced {
+        /// Active durable runtime generation.
+        expected: u64,
+        /// Generation carried by the stale operation.
         actual: u64,
     },
     /// A requested Task does not exist.

--- a/src/cosh-ng/crates/cosh-gateway/src/storage/ledger.rs
+++ b/src/cosh-ng/crates/cosh-gateway/src/storage/ledger.rs
@@ -1,0 +1,1718 @@
+//! Durable approval, permit, execution, runtime binding, and run lease ledger.
+
+use cosh_gateway_contracts::capability::{ApprovalDecision, ExecutionPermit};
+use cosh_gateway_contracts::common::RuntimeBindingRef;
+use cosh_gateway_contracts::common::{
+    BoundedOpaque, BoundedText, Digest, IdempotencyKey, TargetRef,
+};
+use cosh_gateway_contracts::ids::{
+    ActorId, ApprovalId, ExecutionId, PermitId, RequestId, RunId, RuntimeBindingId,
+    RuntimeInstanceId, TaskId,
+};
+use rusqlite::{params, OptionalExtension, Transaction, TransactionBehavior};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+
+use crate::task::TaskAggregate;
+
+use super::{SqliteTaskStore, StoreError};
+
+/// Idempotent command metadata shared by ledger mutations.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LedgerCommand {
+    /// Authenticated actor owning the idempotency namespace.
+    pub actor_id: ActorId,
+    /// Caller-scoped replay key.
+    pub idempotency_key: IdempotencyKey,
+    /// Canonical digest of the complete command.
+    pub command_digest: Digest,
+    /// Durable mutation timestamp in Unix milliseconds.
+    pub committed_at_ms: u64,
+}
+
+/// Result of an idempotent ledger mutation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LedgerOutcome<T> {
+    /// A new durable mutation was applied.
+    Applied(T),
+    /// An identical command returned its original durable result.
+    Replayed(T),
+}
+
+/// Durable approval lifecycle state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ApprovalState {
+    /// Waiting for the bound actor's decision.
+    Pending,
+    /// Approved for subsequent permit issuance.
+    Approved,
+    /// Explicitly denied.
+    Denied,
+    /// Deadline passed before a decision.
+    Expired,
+    /// Owning run cancelled the request.
+    Cancelled,
+}
+
+/// Durable approval row with all authorization bindings.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ApprovalRecord {
+    /// Approval identity.
+    pub approval_id: ApprovalId,
+    /// Capability request identity.
+    pub request_id: RequestId,
+    /// Actor authorized to resolve the approval.
+    pub actor_id: ActorId,
+    /// Owning Task.
+    pub task_id: TaskId,
+    /// Owning Run.
+    pub run_id: RunId,
+    /// Bound target.
+    pub target: TargetRef,
+    /// Bound normalized operation digest.
+    pub operation_digest: Digest,
+    /// Bound complete Runtime input digest.
+    pub input_digest: Digest,
+    /// Current lifecycle state.
+    pub state: ApprovalState,
+    /// Optimistic revision.
+    pub revision: u64,
+    /// Fail-closed decision deadline.
+    pub expires_at_ms: u64,
+    /// Actor that made an explicit decision.
+    pub decided_by_actor_id: Option<ActorId>,
+    /// Creation timestamp.
+    pub created_at_ms: u64,
+    /// Last mutation timestamp.
+    pub updated_at_ms: u64,
+}
+
+/// Requested approval resolution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ApprovalResolution {
+    /// Apply an explicit allow-once decision.
+    Decide(ApprovalDecision),
+    /// Cancel because the owning Run is no longer active.
+    Cancel,
+}
+
+/// Durable permit lifecycle state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PermitState {
+    /// Available for one exact execution.
+    Issued,
+    /// Atomically consumed when execution started.
+    Consumed,
+    /// Deadline passed before consumption.
+    Expired,
+    /// Revoked before consumption.
+    Revoked,
+}
+
+/// Durable execution-permit row.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PermitRecord {
+    /// Complete immutable permit contract.
+    pub permit: ExecutionPermit,
+    /// Current lifecycle state.
+    pub state: PermitState,
+    /// Consumption timestamp.
+    pub consumed_at_ms: Option<u64>,
+    /// Creation timestamp.
+    pub created_at_ms: u64,
+}
+
+/// Durable execution lifecycle state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecutionState {
+    /// Permit was issued but the side effect has not started.
+    Planned,
+    /// Permit consumption and execution start committed atomically.
+    Started,
+    /// A success receipt was committed.
+    Succeeded,
+    /// A failure receipt was committed.
+    Failed,
+    /// Recovery found a started execution without a conclusive receipt.
+    Uncertain,
+}
+
+/// Durable governed execution row.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExecutionRecord {
+    /// Execution identity.
+    pub execution_id: ExecutionId,
+    /// Actor authorized by the permit.
+    pub actor_id: ActorId,
+    /// Owning Task.
+    pub task_id: TaskId,
+    /// Owning Run.
+    pub run_id: RunId,
+    /// Bound target.
+    pub target: TargetRef,
+    /// Bound operation digest.
+    pub operation_digest: Digest,
+    /// Bound Runtime input digest.
+    pub input_digest: Digest,
+    /// Current lifecycle state.
+    pub state: ExecutionState,
+    /// Optimistic revision.
+    pub revision: u64,
+    /// Start timestamp.
+    pub started_at_ms: Option<u64>,
+    /// Terminal or uncertainty timestamp.
+    pub completed_at_ms: Option<u64>,
+    /// Creation timestamp.
+    pub created_at_ms: u64,
+    /// Last mutation timestamp.
+    pub updated_at_ms: u64,
+}
+
+/// Exact bindings presented when consuming a permit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecutionClaim {
+    /// Permit to consume.
+    pub permit_id: PermitId,
+    /// Execution authorized by the permit.
+    pub execution_id: ExecutionId,
+    /// Owning Task.
+    pub task_id: TaskId,
+    /// Owning Run.
+    pub run_id: RunId,
+    /// Exact target.
+    pub target: TargetRef,
+    /// Exact normalized operation digest.
+    pub operation_digest: Digest,
+    /// Exact complete Runtime input digest.
+    pub input_digest: Digest,
+    /// Policy revision expected by the executor.
+    pub policy_revision: u64,
+    /// Current coordinator lease fencing the owning Task and Run.
+    pub lease: LeaseClaim,
+}
+
+/// Conclusive execution result persisted after a started side effect.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExecutionCompletion {
+    /// Execution to complete.
+    pub execution_id: ExecutionId,
+    /// Expected execution revision.
+    pub expected_revision: u64,
+    /// Whether the governed operation succeeded.
+    pub succeeded: bool,
+    /// Digest of the complete evidence receipt.
+    pub receipt_digest: Digest,
+    /// Optional redacted bounded detail.
+    pub safe_detail: Option<BoundedText>,
+}
+
+/// Durable runtime binding lifecycle state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeBindingState {
+    /// Runtime generation may emit events.
+    Active,
+    /// Runtime was closed cleanly.
+    Closed,
+    /// Recovery fenced a runtime whose liveness was not proven.
+    Lost,
+}
+
+/// Durable fenced runtime binding.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RuntimeBindingRecord {
+    /// Complete binding contract.
+    pub binding: RuntimeBindingRef,
+    /// Authenticated Task owner.
+    pub actor_id: ActorId,
+    /// Current binding state.
+    pub state: RuntimeBindingState,
+    /// Last accepted monotonic event sequence.
+    pub last_sequence: u64,
+    /// Creation timestamp.
+    pub created_at_ms: u64,
+    /// Last mutation timestamp.
+    pub updated_at_ms: u64,
+}
+
+/// Run-lease mutation metadata.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LeaseCommand {
+    /// Common idempotent command metadata.
+    pub command: LedgerCommand,
+    /// Task protected by the lease.
+    pub task_id: TaskId,
+    /// Run protected by the lease.
+    pub run_id: RunId,
+    /// Bounded coordinator instance identity.
+    pub lease_owner: BoundedOpaque,
+    /// Requested lease deadline.
+    pub expires_at_ms: u64,
+}
+
+/// Exact fencing claim required to release a Run lease.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LeaseClaim {
+    /// Task protected by the lease.
+    pub task_id: TaskId,
+    /// Run protected by the lease.
+    pub run_id: RunId,
+    /// Coordinator instance holding the lease.
+    pub lease_owner: BoundedOpaque,
+    /// Expected fencing generation.
+    pub generation: u64,
+    /// Expected optimistic revision.
+    pub revision: u64,
+}
+
+/// Durable fenced lease for one Run coordinator.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RunLeaseRecord {
+    /// Owning Task.
+    pub task_id: TaskId,
+    /// Protected Run.
+    pub run_id: RunId,
+    /// Authenticated Task owner.
+    pub actor_id: ActorId,
+    /// Coordinator instance holding the lease.
+    pub lease_owner: BoundedOpaque,
+    /// Monotonic fencing generation.
+    pub generation: u64,
+    /// Optimistic mutation revision.
+    pub revision: u64,
+    /// Lease deadline.
+    pub expires_at_ms: u64,
+    /// Last mutation timestamp.
+    pub updated_at_ms: u64,
+}
+
+/// Counts of fail-closed transitions applied during restart recovery.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RecoveryReport {
+    /// Pending approvals expired by their deadline.
+    pub approvals_expired: u64,
+    /// Issued permits expired by their deadline.
+    pub permits_expired: u64,
+    /// Started executions marked uncertain.
+    pub executions_uncertain: u64,
+    /// Active runtime bindings fenced as lost.
+    pub runtime_bindings_lost: u64,
+}
+
+impl SqliteTaskStore {
+    /// Loads one durable approval record.
+    pub fn load_approval_record(
+        &self,
+        approval_id: &ApprovalId,
+    ) -> Result<ApprovalRecord, StoreError> {
+        load_approval(self.connection(), approval_id)
+    }
+
+    /// Loads one durable permit record.
+    pub fn load_permit_record(&self, permit_id: &PermitId) -> Result<PermitRecord, StoreError> {
+        load_permit(self.connection(), permit_id)
+    }
+
+    /// Loads one durable execution record.
+    pub fn load_execution_record(
+        &self,
+        execution_id: &ExecutionId,
+    ) -> Result<ExecutionRecord, StoreError> {
+        load_execution(self.connection(), execution_id)
+    }
+
+    /// Loads one durable runtime binding record.
+    pub fn load_runtime_binding_record(
+        &self,
+        binding_id: &RuntimeBindingId,
+    ) -> Result<RuntimeBindingRecord, StoreError> {
+        load_runtime_binding(self.connection(), binding_id)
+    }
+
+    /// Loads the current durable lease for a Run.
+    pub fn load_run_lease(&self, run_id: &RunId) -> Result<RunLeaseRecord, StoreError> {
+        load_run_lease_optional(self.connection(), run_id)?
+            .ok_or_else(|| not_found("run lease", run_id.as_str()))
+    }
+
+    /// Creates a pending approval bound to an actor, Task, Run, target, and digests.
+    pub fn create_approval(
+        &mut self,
+        command: &LedgerCommand,
+        approval: &ApprovalRecord,
+    ) -> Result<LedgerOutcome<ApprovalRecord>, StoreError> {
+        validate_command(command)?;
+        integer(approval.expires_at_ms, "approval deadline")?;
+        let transaction = immediate(self)?;
+        if let Some(replayed) = replay(&transaction, command, "create_approval")? {
+            transaction.commit()?;
+            return Ok(LedgerOutcome::Replayed(replayed));
+        }
+        require_task_run(
+            &transaction,
+            &approval.task_id,
+            &approval.run_id,
+            &command.actor_id,
+        )?;
+        if approval.actor_id != command.actor_id
+            || approval.state != ApprovalState::Pending
+            || approval.revision != 1
+            || approval.decided_by_actor_id.is_some()
+            || approval.created_at_ms != command.committed_at_ms
+            || approval.updated_at_ms != command.committed_at_ms
+            || approval.expires_at_ms <= command.committed_at_ms
+        {
+            return Err(conflict("invalid initial approval bindings or lifecycle"));
+        }
+        transaction.execute(
+            "INSERT INTO approvals(approval_id, request_id, actor_id, task_id, run_id,
+             target_json, operation_digest, input_digest, state, revision, expires_at_ms,
+             created_at_ms, updated_at_ms)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, 'pending', 1, ?9, ?10, ?10)",
+            params![
+                approval.approval_id.as_str(),
+                approval.request_id.as_str(),
+                approval.actor_id.as_str(),
+                approval.task_id.as_str(),
+                approval.run_id.as_str(),
+                serde_json::to_string(&approval.target)?,
+                approval.operation_digest.as_str(),
+                approval.input_digest.as_str(),
+                integer(approval.expires_at_ms, "approval deadline")?,
+                integer(command.committed_at_ms, "approval timestamp")?,
+            ],
+        )?;
+        insert_receipt(&transaction, command, "create_approval", approval)?;
+        transaction.commit()?;
+        Ok(LedgerOutcome::Applied(approval.clone()))
+    }
+
+    /// Resolves a pending approval with revision, actor, and deadline checks.
+    pub fn resolve_approval(
+        &mut self,
+        command: &LedgerCommand,
+        approval_id: &ApprovalId,
+        expected_revision: u64,
+        resolution: ApprovalResolution,
+    ) -> Result<LedgerOutcome<ApprovalRecord>, StoreError> {
+        validate_command(command)?;
+        integer(expected_revision, "approval expected revision")?;
+        let transaction = immediate(self)?;
+        if let Some(replayed) = replay(&transaction, command, "resolve_approval")? {
+            transaction.commit()?;
+            return Ok(LedgerOutcome::Replayed(replayed));
+        }
+        let mut record = load_approval(&transaction, approval_id)?;
+        require_task_owner(&transaction, &record.task_id, &command.actor_id)?;
+        if record.actor_id != command.actor_id || record.revision != expected_revision {
+            return Err(conflict("approval actor or revision does not match"));
+        }
+        require_not_before(
+            command.committed_at_ms,
+            record.updated_at_ms,
+            "approval resolution",
+        )?;
+        if record.state != ApprovalState::Pending {
+            return Err(conflict("approval is no longer pending"));
+        }
+        let (state, decided_by) = if command.committed_at_ms >= record.expires_at_ms {
+            (ApprovalState::Expired, None)
+        } else {
+            match resolution {
+                ApprovalResolution::Decide(ApprovalDecision::Approve) => {
+                    (ApprovalState::Approved, Some(command.actor_id.clone()))
+                }
+                ApprovalResolution::Decide(ApprovalDecision::Deny) => {
+                    (ApprovalState::Denied, Some(command.actor_id.clone()))
+                }
+                ApprovalResolution::Cancel => (ApprovalState::Cancelled, None),
+            }
+        };
+        let next_revision = next_integer(record.revision, "approval revision")?;
+        record.state = state;
+        record.revision = next_revision;
+        record.decided_by_actor_id = decided_by;
+        record.updated_at_ms = command.committed_at_ms;
+        let changed = transaction.execute(
+            "UPDATE approvals SET state = ?2, revision = ?3, decided_by_actor_id = ?4,
+             updated_at_ms = ?5 WHERE approval_id = ?1 AND revision = ?6 AND state = 'pending'",
+            params![
+                approval_id.as_str(),
+                state_name(state)?,
+                integer(record.revision, "approval revision")?,
+                record.decided_by_actor_id.as_ref().map(ActorId::as_str),
+                integer(command.committed_at_ms, "approval timestamp")?,
+                integer(expected_revision, "approval expected revision")?
+            ],
+        )?;
+        if changed != 1 {
+            return Err(conflict("approval resolution lost its pending revision"));
+        }
+        insert_receipt(&transaction, command, "resolve_approval", &record)?;
+        transaction.commit()?;
+        Ok(LedgerOutcome::Applied(record))
+    }
+
+    /// Persists a single-use permit and its planned execution atomically.
+    pub fn issue_permit(
+        &mut self,
+        command: &LedgerCommand,
+        permit: &ExecutionPermit,
+    ) -> Result<LedgerOutcome<PermitRecord>, StoreError> {
+        validate_command(command)?;
+        integer(permit.policy_revision, "policy revision")?;
+        integer(permit.valid_until_ms, "permit deadline")?;
+        let transaction = immediate(self)?;
+        if let Some(replayed) = replay(&transaction, command, "issue_permit")? {
+            transaction.commit()?;
+            return Ok(LedgerOutcome::Replayed(replayed));
+        }
+        require_task_run(
+            &transaction,
+            &permit.task_id,
+            &permit.run_id,
+            &command.actor_id,
+        )?;
+        if permit.actor_id != command.actor_id
+            || !permit.single_use
+            || permit.valid_until_ms <= command.committed_at_ms
+        {
+            return Err(conflict(
+                "permit actor, single-use flag, or deadline is invalid",
+            ));
+        }
+        if let Some(approval_id) = &permit.approval_id {
+            let approval = load_approval(&transaction, approval_id)?;
+            if approval.state != ApprovalState::Approved
+                || approval.request_id != permit.request_id
+                || approval.actor_id != permit.actor_id
+                || approval.task_id != permit.task_id
+                || approval.run_id != permit.run_id
+                || approval.target != permit.target
+                || approval.operation_digest != permit.operation_digest
+                || approval.input_digest != permit.input_digest
+                || approval.expires_at_ms <= command.committed_at_ms
+                || permit.valid_until_ms > approval.expires_at_ms
+                || command.committed_at_ms < approval.updated_at_ms
+            {
+                return Err(conflict(
+                    "approved request does not exactly bind the permit",
+                ));
+            }
+        }
+        let target_json = serde_json::to_string(&permit.target)?;
+        let now = integer(command.committed_at_ms, "permit timestamp")?;
+        transaction.execute(
+            "INSERT INTO executions(execution_id, actor_id, task_id, run_id, target_json,
+             operation_digest, input_digest, state, revision, created_at_ms, updated_at_ms)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 'planned', 1, ?8, ?8)",
+            params![
+                permit.execution_id.as_str(),
+                permit.actor_id.as_str(),
+                permit.task_id.as_str(),
+                permit.run_id.as_str(),
+                target_json,
+                permit.operation_digest.as_str(),
+                permit.input_digest.as_str(),
+                now
+            ],
+        )?;
+        transaction.execute(
+            "INSERT INTO permits(permit_id, request_id, approval_id, actor_id, task_id, run_id,
+             execution_id, target_json, operation_digest, input_digest, policy_revision, state,
+             single_use, valid_until_ms, created_at_ms)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, 'issued', 1, ?12, ?13)",
+            params![
+                permit.permit_id.as_str(),
+                permit.request_id.as_str(),
+                permit.approval_id.as_ref().map(ApprovalId::as_str),
+                permit.actor_id.as_str(),
+                permit.task_id.as_str(),
+                permit.run_id.as_str(),
+                permit.execution_id.as_str(),
+                serde_json::to_string(&permit.target)?,
+                permit.operation_digest.as_str(),
+                permit.input_digest.as_str(),
+                integer(permit.policy_revision, "policy revision")?,
+                integer(permit.valid_until_ms, "permit deadline")?,
+                now
+            ],
+        )?;
+        let record = PermitRecord {
+            permit: permit.clone(),
+            state: PermitState::Issued,
+            consumed_at_ms: None,
+            created_at_ms: command.committed_at_ms,
+        };
+        insert_receipt(&transaction, command, "issue_permit", &record)?;
+        transaction.commit()?;
+        Ok(LedgerOutcome::Applied(record))
+    }
+
+    /// Revokes an issued permit before execution starts.
+    pub fn revoke_permit(
+        &mut self,
+        command: &LedgerCommand,
+        permit_id: &PermitId,
+    ) -> Result<LedgerOutcome<PermitRecord>, StoreError> {
+        validate_command(command)?;
+        let transaction = immediate(self)?;
+        if let Some(replayed) = replay(&transaction, command, "revoke_permit")? {
+            transaction.commit()?;
+            return Ok(LedgerOutcome::Replayed(replayed));
+        }
+        let mut record = load_permit(&transaction, permit_id)?;
+        require_task_owner(&transaction, &record.permit.task_id, &command.actor_id)?;
+        require_not_before(
+            command.committed_at_ms,
+            record.created_at_ms,
+            "permit revocation",
+        )?;
+        if record.permit.actor_id != command.actor_id || record.state != PermitState::Issued {
+            return Err(conflict("only the bound actor may revoke an issued permit"));
+        }
+        let changed = transaction.execute(
+            "UPDATE permits SET state='revoked' WHERE permit_id=?1 AND state='issued'",
+            params![permit_id.as_str()],
+        )?;
+        if changed != 1 {
+            return Err(conflict(
+                "permit revocation lost its issued-state precondition",
+            ));
+        }
+        record.state = PermitState::Revoked;
+        insert_receipt(&transaction, command, "revoke_permit", &record)?;
+        transaction.commit()?;
+        Ok(LedgerOutcome::Applied(record))
+    }
+
+    /// Consumes one exact permit and marks its execution started in one transaction.
+    pub fn consume_permit_and_start_execution(
+        &mut self,
+        command: &LedgerCommand,
+        claim: &ExecutionClaim,
+    ) -> Result<LedgerOutcome<ExecutionRecord>, StoreError> {
+        validate_command(command)?;
+        let transaction = immediate(self)?;
+        if let Some(replayed) = replay(&transaction, command, "consume_permit")? {
+            transaction.commit()?;
+            return Ok(LedgerOutcome::Replayed(replayed));
+        }
+        require_task_run(
+            &transaction,
+            &claim.task_id,
+            &claim.run_id,
+            &command.actor_id,
+        )?;
+        if claim.lease.task_id != claim.task_id || claim.lease.run_id != claim.run_id {
+            return Err(conflict(
+                "execution lease does not bind the claimed Task and Run",
+            ));
+        }
+        require_current_lease(
+            &transaction,
+            &claim.lease,
+            &command.actor_id,
+            command.committed_at_ms,
+        )?;
+        integer(claim.policy_revision, "execution policy revision")?;
+        let permit = load_permit(&transaction, &claim.permit_id)?;
+        if permit.state != PermitState::Issued
+            || permit.permit.actor_id != command.actor_id
+            || permit.permit.execution_id != claim.execution_id
+            || permit.permit.task_id != claim.task_id
+            || permit.permit.run_id != claim.run_id
+            || permit.permit.target != claim.target
+            || permit.permit.operation_digest != claim.operation_digest
+            || permit.permit.input_digest != claim.input_digest
+            || permit.permit.policy_revision != claim.policy_revision
+        {
+            return Err(conflict(
+                "execution claim does not exactly match an issued permit",
+            ));
+        }
+        if command.committed_at_ms >= permit.permit.valid_until_ms {
+            return Err(conflict("permit expired before execution start"));
+        }
+        require_not_before(
+            command.committed_at_ms,
+            permit.created_at_ms,
+            "execution start",
+        )?;
+        let now = integer(command.committed_at_ms, "execution start timestamp")?;
+        let changed = transaction.execute(
+            "UPDATE permits SET state = 'consumed', consumed_at_ms = ?2
+             WHERE permit_id = ?1 AND state = 'issued' AND consumed_at_ms IS NULL",
+            params![claim.permit_id.as_str(), now],
+        )?;
+        let started = transaction.execute(
+            "UPDATE executions SET state = 'started', revision = 2, started_at_ms = ?2,
+             updated_at_ms = ?2 WHERE execution_id = ?1 AND state = 'planned' AND revision = 1",
+            params![claim.execution_id.as_str(), now],
+        )?;
+        if changed != 1 || started != 1 {
+            return Err(conflict(
+                "permit consumption or execution start lost its precondition",
+            ));
+        }
+        let record = load_execution(&transaction, &claim.execution_id)?;
+        insert_receipt(&transaction, command, "consume_permit", &record)?;
+        transaction.commit()?;
+        Ok(LedgerOutcome::Applied(record))
+    }
+
+    /// Commits a conclusive receipt for a started execution.
+    pub fn complete_execution(
+        &mut self,
+        command: &LedgerCommand,
+        completion: &ExecutionCompletion,
+    ) -> Result<LedgerOutcome<ExecutionRecord>, StoreError> {
+        validate_command(command)?;
+        integer(completion.expected_revision, "execution expected revision")?;
+        let transaction = immediate(self)?;
+        if let Some(replayed) = replay(&transaction, command, "complete_execution")? {
+            transaction.commit()?;
+            return Ok(LedgerOutcome::Replayed(replayed));
+        }
+        let mut record = load_execution(&transaction, &completion.execution_id)?;
+        require_task_owner(&transaction, &record.task_id, &command.actor_id)?;
+        if record.actor_id != command.actor_id
+            || record.state != ExecutionState::Started
+            || record.revision != completion.expected_revision
+        {
+            return Err(conflict(
+                "execution actor, state, or revision does not match",
+            ));
+        }
+        require_not_before(
+            command.committed_at_ms,
+            record.updated_at_ms,
+            "execution completion",
+        )?;
+        let next_revision = next_integer(record.revision, "execution revision")?;
+        record.state = if completion.succeeded {
+            ExecutionState::Succeeded
+        } else {
+            ExecutionState::Failed
+        };
+        record.revision = next_revision;
+        record.completed_at_ms = Some(command.committed_at_ms);
+        record.updated_at_ms = command.committed_at_ms;
+        let state = state_name(record.state)?;
+        let now = integer(command.committed_at_ms, "execution completion timestamp")?;
+        let changed = transaction.execute(
+            "UPDATE executions SET state = ?2, revision = ?3, completed_at_ms = ?4,
+             updated_at_ms = ?4 WHERE execution_id = ?1 AND state = 'started' AND revision = ?5",
+            params![
+                completion.execution_id.as_str(),
+                state,
+                integer(record.revision, "execution revision")?,
+                now,
+                integer(completion.expected_revision, "execution expected revision")?
+            ],
+        )?;
+        if changed != 1 {
+            return Err(conflict("execution completion lost its started revision"));
+        }
+        transaction.execute(
+            "INSERT INTO execution_receipts(execution_id, state, receipt_digest, safe_detail,
+             committed_at_ms) VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![
+                completion.execution_id.as_str(),
+                state,
+                completion.receipt_digest.as_str(),
+                completion.safe_detail.as_ref().map(BoundedText::as_str),
+                now
+            ],
+        )?;
+        insert_receipt(&transaction, command, "complete_execution", &record)?;
+        transaction.commit()?;
+        Ok(LedgerOutcome::Applied(record))
+    }
+
+    /// Persists a new runtime generation and fences older active bindings for the Run.
+    pub fn bind_runtime(
+        &mut self,
+        command: &LedgerCommand,
+        binding: &RuntimeBindingRef,
+        lease: &LeaseClaim,
+    ) -> Result<LedgerOutcome<RuntimeBindingRecord>, StoreError> {
+        validate_command(command)?;
+        integer(binding.runtime_generation, "runtime generation")?;
+        let transaction = immediate(self)?;
+        if let Some(replayed) = replay(&transaction, command, "bind_runtime")? {
+            transaction.commit()?;
+            return Ok(LedgerOutcome::Replayed(replayed));
+        }
+        require_task_run(
+            &transaction,
+            &binding.task_id,
+            &binding.run_id,
+            &command.actor_id,
+        )?;
+        if lease.task_id != binding.task_id || lease.run_id != binding.run_id {
+            return Err(conflict(
+                "runtime binding lease does not bind the Runtime Task and Run",
+            ));
+        }
+        require_current_lease(
+            &transaction,
+            lease,
+            &command.actor_id,
+            command.committed_at_ms,
+        )?;
+        let highest = transaction.query_row(
+            "SELECT COALESCE(MAX(runtime_generation), 0) FROM runtime_bindings WHERE run_id = ?1",
+            params![binding.run_id.as_str()],
+            |row| row.get::<_, i64>(0),
+        )?;
+        let highest = unsigned(highest, "runtime generation")?;
+        let expected = next_integer(highest, "runtime generation")?;
+        if binding.runtime_generation != expected {
+            return Err(StoreError::GenerationFenced {
+                expected,
+                actual: binding.runtime_generation,
+            });
+        }
+        let now = integer(command.committed_at_ms, "runtime binding timestamp")?;
+        let latest_update = transaction.query_row(
+            "SELECT COALESCE(MAX(updated_at_ms), 0) FROM runtime_bindings WHERE run_id=?1",
+            params![binding.run_id.as_str()],
+            |row| row.get::<_, i64>(0),
+        )?;
+        require_not_before(
+            command.committed_at_ms,
+            unsigned(latest_update, "runtime binding update")?,
+            "runtime binding",
+        )?;
+        transaction.execute(
+            "UPDATE runtime_bindings SET state = 'lost', updated_at_ms = ?2
+             WHERE run_id = ?1 AND state = 'active'",
+            params![binding.run_id.as_str(), now],
+        )?;
+        transaction.execute(
+            "INSERT INTO runtime_bindings(binding_id, actor_id, task_id, run_id,
+             runtime_instance_id, runtime_generation, binding_json, state, last_sequence,
+             created_at_ms, updated_at_ms) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 'active', 0, ?8, ?8)",
+            params![binding.binding_id.as_str(), command.actor_id.as_str(), binding.task_id.as_str(),
+                binding.run_id.as_str(), binding.runtime_instance_id.as_str(),
+                integer(binding.runtime_generation, "runtime generation")?,
+                serde_json::to_string(binding)?, now],
+        )?;
+        let record = RuntimeBindingRecord {
+            binding: binding.clone(),
+            actor_id: command.actor_id.clone(),
+            state: RuntimeBindingState::Active,
+            last_sequence: 0,
+            created_at_ms: command.committed_at_ms,
+            updated_at_ms: command.committed_at_ms,
+        };
+        insert_receipt(&transaction, command, "bind_runtime", &record)?;
+        transaction.commit()?;
+        Ok(LedgerOutcome::Applied(record))
+    }
+
+    /// Advances a binding's sequence only for its exact active process generation.
+    pub fn record_runtime_sequence(
+        &mut self,
+        binding_id: &RuntimeBindingId,
+        runtime_instance_id: &RuntimeInstanceId,
+        runtime_generation: u64,
+        sequence: u64,
+        updated_at_ms: u64,
+        lease: &LeaseClaim,
+    ) -> Result<RuntimeBindingRecord, StoreError> {
+        integer(runtime_generation, "runtime generation")?;
+        integer(sequence, "runtime sequence")?;
+        integer(updated_at_ms, "runtime event timestamp")?;
+        let transaction = immediate(self)?;
+        let record = load_runtime_binding(&transaction, binding_id)?;
+        if lease.task_id != record.binding.task_id || lease.run_id != record.binding.run_id {
+            return Err(conflict(
+                "runtime event lease does not bind the runtime Task and Run",
+            ));
+        }
+        require_current_lease(&transaction, lease, &record.actor_id, updated_at_ms)?;
+        require_not_before(
+            updated_at_ms,
+            record.updated_at_ms,
+            "runtime event acceptance",
+        )?;
+        if record.binding.runtime_generation != runtime_generation {
+            return Err(StoreError::GenerationFenced {
+                expected: record.binding.runtime_generation,
+                actual: runtime_generation,
+            });
+        }
+        let expected_sequence = next_integer(record.last_sequence, "runtime sequence")?;
+        if record.state != RuntimeBindingState::Active
+            || &record.binding.runtime_instance_id != runtime_instance_id
+            || sequence != expected_sequence
+        {
+            return Err(conflict(
+                "runtime instance, state, or event sequence is stale",
+            ));
+        }
+        let changed = transaction.execute(
+            "UPDATE runtime_bindings SET last_sequence = ?2, updated_at_ms = ?3
+             WHERE binding_id = ?1 AND state = 'active' AND runtime_generation = ?4
+             AND last_sequence = ?5",
+            params![
+                binding_id.as_str(),
+                integer(sequence, "runtime sequence")?,
+                integer(updated_at_ms, "runtime event timestamp")?,
+                integer(runtime_generation, "runtime generation")?,
+                integer(record.last_sequence, "runtime prior sequence")?
+            ],
+        )?;
+        if changed != 1 {
+            return Err(conflict(
+                "runtime sequence lost its active-generation precondition",
+            ));
+        }
+        let updated = load_runtime_binding(&transaction, binding_id)?;
+        transaction.commit()?;
+        Ok(updated)
+    }
+
+    /// Closes an active runtime binding only for its exact fenced generation.
+    pub fn close_runtime_binding(
+        &mut self,
+        command: &LedgerCommand,
+        binding_id: &RuntimeBindingId,
+        runtime_generation: u64,
+        lease: &LeaseClaim,
+    ) -> Result<LedgerOutcome<RuntimeBindingRecord>, StoreError> {
+        validate_command(command)?;
+        integer(runtime_generation, "runtime generation")?;
+        let transaction = immediate(self)?;
+        if let Some(replayed) = replay(&transaction, command, "close_runtime_binding")? {
+            transaction.commit()?;
+            return Ok(LedgerOutcome::Replayed(replayed));
+        }
+        let mut record = load_runtime_binding(&transaction, binding_id)?;
+        require_task_owner(&transaction, &record.binding.task_id, &command.actor_id)?;
+        if lease.task_id != record.binding.task_id || lease.run_id != record.binding.run_id {
+            return Err(conflict(
+                "runtime close lease does not bind the Runtime Task and Run",
+            ));
+        }
+        require_current_lease(
+            &transaction,
+            lease,
+            &command.actor_id,
+            command.committed_at_ms,
+        )?;
+        if record.actor_id != command.actor_id {
+            return Err(conflict("runtime binding actor does not match"));
+        }
+        if record.binding.runtime_generation != runtime_generation {
+            return Err(StoreError::GenerationFenced {
+                expected: record.binding.runtime_generation,
+                actual: runtime_generation,
+            });
+        }
+        if record.state != RuntimeBindingState::Active {
+            return Err(conflict("runtime binding is not active"));
+        }
+        require_not_before(
+            command.committed_at_ms,
+            record.updated_at_ms,
+            "runtime close",
+        )?;
+        record.state = RuntimeBindingState::Closed;
+        record.updated_at_ms = command.committed_at_ms;
+        let changed = transaction.execute(
+            "UPDATE runtime_bindings SET state='closed', updated_at_ms=?2
+             WHERE binding_id=?1 AND state='active' AND runtime_generation=?3",
+            params![
+                binding_id.as_str(),
+                integer(command.committed_at_ms, "runtime close timestamp")?,
+                integer(runtime_generation, "runtime generation")?
+            ],
+        )?;
+        if changed != 1 {
+            return Err(conflict(
+                "runtime close lost its active-generation precondition",
+            ));
+        }
+        insert_receipt(&transaction, command, "close_runtime_binding", &record)?;
+        transaction.commit()?;
+        Ok(LedgerOutcome::Applied(record))
+    }
+
+    /// Acquires an absent or expired Run lease with a monotonically increasing generation.
+    pub fn acquire_run_lease(
+        &mut self,
+        lease: &LeaseCommand,
+    ) -> Result<LedgerOutcome<RunLeaseRecord>, StoreError> {
+        validate_command(&lease.command)?;
+        integer(lease.expires_at_ms, "lease deadline")?;
+        let transaction = immediate(self)?;
+        if let Some(replayed) = replay(&transaction, &lease.command, "acquire_run_lease")? {
+            transaction.commit()?;
+            return Ok(LedgerOutcome::Replayed(replayed));
+        }
+        require_task_run(
+            &transaction,
+            &lease.task_id,
+            &lease.run_id,
+            &lease.command.actor_id,
+        )?;
+        if lease.expires_at_ms <= lease.command.committed_at_ms {
+            return Err(conflict("run lease deadline must be in the future"));
+        }
+        let existing = load_run_lease_optional(&transaction, &lease.run_id)?;
+        if let Some(existing) = &existing {
+            if existing.task_id != lease.task_id || existing.actor_id != lease.command.actor_id {
+                return Err(conflict(
+                    "run lease Task or actor binding cannot be replaced",
+                ));
+            }
+            if existing.expires_at_ms > lease.command.committed_at_ms {
+                return Err(conflict("run lease is still held"));
+            }
+            require_not_before(
+                lease.command.committed_at_ms,
+                existing.updated_at_ms,
+                "run lease takeover",
+            )?;
+        }
+        let generation = match &existing {
+            Some(row) => next_integer(row.generation, "lease generation")?,
+            None => 1,
+        };
+        let revision = match &existing {
+            Some(row) => next_integer(row.revision, "lease revision")?,
+            None => 1,
+        };
+        let record = RunLeaseRecord {
+            task_id: lease.task_id.clone(),
+            run_id: lease.run_id.clone(),
+            actor_id: lease.command.actor_id.clone(),
+            lease_owner: lease.lease_owner.clone(),
+            generation,
+            revision,
+            expires_at_ms: lease.expires_at_ms,
+            updated_at_ms: lease.command.committed_at_ms,
+        };
+        transaction.execute(
+            "INSERT INTO run_leases(run_id, task_id, actor_id, lease_owner, generation, revision,
+             expires_at_ms, updated_at_ms) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)
+             ON CONFLICT(run_id) DO UPDATE SET task_id=excluded.task_id, actor_id=excluded.actor_id,
+             lease_owner=excluded.lease_owner, generation=excluded.generation,
+             revision=excluded.revision, expires_at_ms=excluded.expires_at_ms,
+             updated_at_ms=excluded.updated_at_ms",
+            params![
+                record.run_id.as_str(),
+                record.task_id.as_str(),
+                record.actor_id.as_str(),
+                record.lease_owner.as_str(),
+                integer(record.generation, "lease generation")?,
+                integer(record.revision, "lease revision")?,
+                integer(record.expires_at_ms, "lease deadline")?,
+                integer(record.updated_at_ms, "lease timestamp")?
+            ],
+        )?;
+        insert_receipt(&transaction, &lease.command, "acquire_run_lease", &record)?;
+        transaction.commit()?;
+        Ok(LedgerOutcome::Applied(record))
+    }
+
+    /// Renews an active Run lease without changing its fencing generation.
+    pub fn renew_run_lease(
+        &mut self,
+        lease: &LeaseCommand,
+        expected_generation: u64,
+        expected_revision: u64,
+    ) -> Result<LedgerOutcome<RunLeaseRecord>, StoreError> {
+        validate_command(&lease.command)?;
+        integer(expected_generation, "lease generation")?;
+        integer(expected_revision, "lease expected revision")?;
+        integer(lease.expires_at_ms, "lease deadline")?;
+        let transaction = immediate(self)?;
+        if let Some(replayed) = replay(&transaction, &lease.command, "renew_run_lease")? {
+            transaction.commit()?;
+            return Ok(LedgerOutcome::Replayed(replayed));
+        }
+        require_task_run(
+            &transaction,
+            &lease.task_id,
+            &lease.run_id,
+            &lease.command.actor_id,
+        )?;
+        let existing = load_run_lease_optional(&transaction, &lease.run_id)?
+            .ok_or_else(|| not_found("run lease", lease.run_id.as_str()))?;
+        if existing.task_id != lease.task_id
+            || existing.actor_id != lease.command.actor_id
+            || existing.lease_owner != lease.lease_owner
+            || existing.generation != expected_generation
+            || existing.revision != expected_revision
+            || existing.expires_at_ms <= lease.command.committed_at_ms
+            || lease.expires_at_ms <= lease.command.committed_at_ms
+        {
+            return Err(conflict(
+                "run lease renewal binding, revision, or deadline is stale",
+            ));
+        }
+        require_not_before(
+            lease.command.committed_at_ms,
+            existing.updated_at_ms,
+            "run lease renewal",
+        )?;
+        let next_revision = next_integer(existing.revision, "lease revision")?;
+        let record = RunLeaseRecord {
+            revision: next_revision,
+            expires_at_ms: lease.expires_at_ms,
+            updated_at_ms: lease.command.committed_at_ms,
+            ..existing
+        };
+        let changed = transaction.execute(
+            "UPDATE run_leases SET revision=?2, expires_at_ms=?3, updated_at_ms=?4
+             WHERE run_id=?1 AND generation=?5 AND revision=?6 AND lease_owner=?7",
+            params![
+                record.run_id.as_str(),
+                integer(record.revision, "lease revision")?,
+                integer(record.expires_at_ms, "lease deadline")?,
+                integer(record.updated_at_ms, "lease update")?,
+                integer(expected_generation, "lease generation")?,
+                integer(expected_revision, "lease expected revision")?,
+                record.lease_owner.as_str()
+            ],
+        )?;
+        if changed != 1 {
+            return Err(conflict("run lease renewal lost its fencing precondition"));
+        }
+        insert_receipt(&transaction, &lease.command, "renew_run_lease", &record)?;
+        transaction.commit()?;
+        Ok(LedgerOutcome::Applied(record))
+    }
+
+    /// Releases an active Run lease while retaining its fencing generation.
+    pub fn release_run_lease(
+        &mut self,
+        command: &LedgerCommand,
+        claim: &LeaseClaim,
+    ) -> Result<LedgerOutcome<RunLeaseRecord>, StoreError> {
+        validate_command(command)?;
+        integer(claim.generation, "lease generation")?;
+        integer(claim.revision, "lease expected revision")?;
+        let transaction = immediate(self)?;
+        if let Some(replayed) = replay(&transaction, command, "release_run_lease")? {
+            transaction.commit()?;
+            return Ok(LedgerOutcome::Replayed(replayed));
+        }
+        require_task_run(
+            &transaction,
+            &claim.task_id,
+            &claim.run_id,
+            &command.actor_id,
+        )?;
+        let existing = load_run_lease_optional(&transaction, &claim.run_id)?
+            .ok_or_else(|| not_found("run lease", claim.run_id.as_str()))?;
+        if existing.task_id != claim.task_id
+            || existing.actor_id != command.actor_id
+            || existing.lease_owner != claim.lease_owner
+            || existing.generation != claim.generation
+            || existing.revision != claim.revision
+            || existing.expires_at_ms <= command.committed_at_ms
+        {
+            return Err(conflict(
+                "run lease release binding, revision, or deadline is stale",
+            ));
+        }
+        require_not_before(
+            command.committed_at_ms,
+            existing.updated_at_ms,
+            "run lease release",
+        )?;
+        let next_revision = next_integer(existing.revision, "lease revision")?;
+        let record = RunLeaseRecord {
+            revision: next_revision,
+            expires_at_ms: command.committed_at_ms,
+            updated_at_ms: command.committed_at_ms,
+            ..existing
+        };
+        let changed = transaction.execute(
+            "UPDATE run_leases SET revision=?2, expires_at_ms=?3, updated_at_ms=?3
+             WHERE run_id=?1 AND generation=?4 AND revision=?5 AND lease_owner=?6",
+            params![
+                record.run_id.as_str(),
+                integer(record.revision, "lease revision")?,
+                integer(record.updated_at_ms, "lease release timestamp")?,
+                integer(claim.generation, "lease generation")?,
+                integer(claim.revision, "lease expected revision")?,
+                record.lease_owner.as_str()
+            ],
+        )?;
+        if changed != 1 {
+            return Err(conflict("run lease release lost its fencing precondition"));
+        }
+        insert_receipt(&transaction, command, "release_run_lease", &record)?;
+        transaction.commit()?;
+        Ok(LedgerOutcome::Applied(record))
+    }
+
+    /// Recovers durable state conservatively without retrying side effects.
+    pub fn recover_gateway(&mut self, now_ms: u64) -> Result<RecoveryReport, StoreError> {
+        let transaction = immediate(self)?;
+        let now = integer(now_ms, "recovery timestamp")?;
+        validate_all_execution_receipts(&transaction)?;
+        let approvals_expired = transaction.execute(
+            "UPDATE approvals SET state='expired', revision=revision+1, updated_at_ms=?1
+             WHERE state='pending' AND expires_at_ms <= ?1",
+            params![now],
+        )?;
+        let permits_expired = transaction.execute(
+            "UPDATE permits SET state='expired' WHERE state='issued' AND valid_until_ms <= ?1",
+            params![now],
+        )?;
+        let executions_uncertain = transaction.execute(
+            "UPDATE executions SET state='uncertain', revision=revision+1, completed_at_ms=?1,
+             updated_at_ms=?1 WHERE state='started'",
+            params![now],
+        )?;
+        let runtime_bindings_lost = transaction.execute(
+            "UPDATE runtime_bindings SET state='lost', updated_at_ms=?1 WHERE state='active'",
+            params![now],
+        )?;
+        transaction.commit()?;
+        Ok(RecoveryReport {
+            approvals_expired: approvals_expired as u64,
+            permits_expired: permits_expired as u64,
+            executions_uncertain: executions_uncertain as u64,
+            runtime_bindings_lost: runtime_bindings_lost as u64,
+        })
+    }
+}
+
+fn immediate(store: &mut SqliteTaskStore) -> Result<Transaction<'_>, StoreError> {
+    Ok(store
+        .connection_mut()
+        .transaction_with_behavior(TransactionBehavior::Immediate)?)
+}
+
+fn require_task_owner(
+    transaction: &Transaction<'_>,
+    task_id: &TaskId,
+    actor_id: &ActorId,
+) -> Result<(), StoreError> {
+    let task = load_authoritative_task(transaction, task_id)?;
+    if task.owner_actor_id() == actor_id {
+        Ok(())
+    } else {
+        Err(conflict("actor does not own the bound Task"))
+    }
+}
+
+fn require_task_run(
+    transaction: &Transaction<'_>,
+    task_id: &TaskId,
+    run_id: &RunId,
+    actor_id: &ActorId,
+) -> Result<(), StoreError> {
+    let task = load_authoritative_task(transaction, task_id)?;
+    if task.owner_actor_id() != actor_id {
+        return Err(conflict("actor does not own the bound Task"));
+    }
+    if task.active_run_id() != Some(run_id) {
+        return Err(conflict(
+            "Run is not the authoritative active Run for the bound Task",
+        ));
+    }
+    Ok(())
+}
+
+fn load_authoritative_task(
+    transaction: &Transaction<'_>,
+    task_id: &TaskId,
+) -> Result<TaskAggregate, StoreError> {
+    let snapshot_json = transaction
+        .query_row(
+            "SELECT snapshot_json FROM tasks WHERE task_id=?1",
+            params![task_id.as_str()],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+        .ok_or(StoreError::TaskNotFound)?;
+    let snapshot = serde_json::from_str::<TaskAggregate>(&snapshot_json)
+        .map_err(|error| corrupt(&format!("Task snapshot cannot be decoded: {error}")))?;
+    let mut statement = transaction
+        .prepare("SELECT payload_json FROM task_events WHERE task_id=?1 ORDER BY revision ASC")?;
+    let payloads = statement
+        .query_map(params![task_id.as_str()], |row| row.get::<_, String>(0))?
+        .collect::<Result<Vec<_>, _>>()?;
+    if payloads.is_empty() {
+        return Err(corrupt("Task projection has no event stream"));
+    }
+    let events = payloads
+        .into_iter()
+        .map(|payload| {
+            serde_json::from_str(&payload)
+                .map_err(|error| corrupt(&format!("Task event cannot be decoded: {error}")))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let recovered = TaskAggregate::replay(&events)?;
+    if recovered != snapshot || recovered.task_id() != task_id {
+        return Err(corrupt(
+            "Task projection diverges from its authoritative event stream",
+        ));
+    }
+    Ok(recovered)
+}
+
+fn require_current_lease(
+    transaction: &Transaction<'_>,
+    claim: &LeaseClaim,
+    actor_id: &ActorId,
+    now_ms: u64,
+) -> Result<(), StoreError> {
+    integer(claim.generation, "lease generation")?;
+    integer(claim.revision, "lease revision")?;
+    let current = load_run_lease_optional(transaction, &claim.run_id)?
+        .ok_or_else(|| not_found("run lease", claim.run_id.as_str()))?;
+    require_task_run(transaction, &claim.task_id, &claim.run_id, actor_id)?;
+    if current.task_id != claim.task_id
+        || current.actor_id != *actor_id
+        || current.lease_owner != claim.lease_owner
+        || current.generation != claim.generation
+        || current.revision != claim.revision
+        || current.expires_at_ms <= now_ms
+    {
+        return Err(conflict("run lease fencing claim is stale or expired"));
+    }
+    Ok(())
+}
+
+fn replay<T: DeserializeOwned>(
+    transaction: &Transaction<'_>,
+    command: &LedgerCommand,
+    operation: &str,
+) -> Result<Option<T>, StoreError> {
+    let used_by_task = transaction.query_row(
+        "SELECT EXISTS(SELECT 1 FROM command_receipts
+         WHERE actor_id=?1 AND idempotency_key=?2)",
+        params![command.actor_id.as_str(), command.idempotency_key.as_str()],
+        |row| row.get::<_, bool>(0),
+    )?;
+    if used_by_task {
+        return Err(StoreError::IdempotencyConflict);
+    }
+    let row = transaction
+        .query_row(
+            "SELECT command_digest, operation, result_json FROM ledger_receipts
+         WHERE actor_id=?1 AND idempotency_key=?2",
+            params![command.actor_id.as_str(), command.idempotency_key.as_str()],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                ))
+            },
+        )
+        .optional()?;
+    let Some((digest, stored_operation, result)) = row else {
+        return Ok(None);
+    };
+    if digest != command.command_digest.as_str() || stored_operation != operation {
+        return Err(StoreError::IdempotencyConflict);
+    }
+    Ok(Some(serde_json::from_str(&result)?))
+}
+
+fn insert_receipt<T: Serialize>(
+    transaction: &Transaction<'_>,
+    command: &LedgerCommand,
+    operation: &str,
+    result: &T,
+) -> Result<(), StoreError> {
+    transaction.execute(
+        "INSERT INTO ledger_receipts(actor_id, idempotency_key, command_digest, operation,
+         result_json, committed_at_ms) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        params![
+            command.actor_id.as_str(),
+            command.idempotency_key.as_str(),
+            command.command_digest.as_str(),
+            operation,
+            serde_json::to_string(result)?,
+            integer(command.committed_at_ms, "ledger timestamp")?
+        ],
+    )?;
+    Ok(())
+}
+
+fn load_approval(
+    transaction: &rusqlite::Connection,
+    id: &ApprovalId,
+) -> Result<ApprovalRecord, StoreError> {
+    transaction
+        .query_row(
+            "SELECT request_id, actor_id, task_id, run_id, target_json, operation_digest,
+         input_digest, state, revision, expires_at_ms, decided_by_actor_id, created_at_ms,
+         updated_at_ms FROM approvals WHERE approval_id=?1",
+            params![id.as_str()],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, String>(3)?,
+                    row.get::<_, String>(4)?,
+                    row.get::<_, String>(5)?,
+                    row.get::<_, String>(6)?,
+                    row.get::<_, String>(7)?,
+                    row.get::<_, i64>(8)?,
+                    row.get::<_, i64>(9)?,
+                    row.get::<_, Option<String>>(10)?,
+                    row.get::<_, i64>(11)?,
+                    row.get::<_, i64>(12)?,
+                ))
+            },
+        )
+        .optional()?
+        .ok_or_else(|| not_found("approval", id.as_str()))
+        .and_then(|row| {
+            Ok(ApprovalRecord {
+                approval_id: id.clone(),
+                request_id: parse_id(&row.0)?,
+                actor_id: parse_id(&row.1)?,
+                task_id: parse_id(&row.2)?,
+                run_id: parse_id(&row.3)?,
+                target: serde_json::from_str(&row.4)?,
+                operation_digest: Digest::parse(row.5)
+                    .map_err(|_| corrupt("invalid approval operation digest"))?,
+                input_digest: Digest::parse(row.6)
+                    .map_err(|_| corrupt("invalid approval input digest"))?,
+                state: parse_approval_state(&row.7)?,
+                revision: unsigned(row.8, "approval revision")?,
+                expires_at_ms: unsigned(row.9, "approval deadline")?,
+                decided_by_actor_id: row.10.map(|value| parse_id(&value)).transpose()?,
+                created_at_ms: unsigned(row.11, "approval creation")?,
+                updated_at_ms: unsigned(row.12, "approval update")?,
+            })
+        })
+}
+
+fn load_permit(
+    transaction: &rusqlite::Connection,
+    id: &PermitId,
+) -> Result<PermitRecord, StoreError> {
+    let row = transaction
+        .query_row(
+            "SELECT request_id, approval_id, actor_id, task_id, run_id, execution_id, target_json,
+         operation_digest, input_digest, policy_revision, state, single_use, valid_until_ms,
+         consumed_at_ms, created_at_ms FROM permits WHERE permit_id=?1",
+            params![id.as_str()],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, Option<String>>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, String>(3)?,
+                    row.get::<_, String>(4)?,
+                    row.get::<_, String>(5)?,
+                    row.get::<_, String>(6)?,
+                    row.get::<_, String>(7)?,
+                    row.get::<_, String>(8)?,
+                    row.get::<_, i64>(9)?,
+                    row.get::<_, String>(10)?,
+                    row.get::<_, i64>(11)?,
+                    row.get::<_, i64>(12)?,
+                    row.get::<_, Option<i64>>(13)?,
+                    row.get::<_, i64>(14)?,
+                ))
+            },
+        )
+        .optional()?
+        .ok_or_else(|| not_found("permit", id.as_str()))?;
+    if row.11 != 1 {
+        return Err(corrupt("durable permit is not single-use"));
+    }
+    Ok(PermitRecord {
+        permit: ExecutionPermit {
+            permit_id: id.clone(),
+            request_id: parse_id(&row.0)?,
+            approval_id: row.1.map(|value| parse_id(&value)).transpose()?,
+            actor_id: parse_id(&row.2)?,
+            task_id: parse_id(&row.3)?,
+            run_id: parse_id(&row.4)?,
+            execution_id: parse_id(&row.5)?,
+            target: serde_json::from_str(&row.6)?,
+            operation_digest: Digest::parse(row.7)
+                .map_err(|_| corrupt("invalid permit operation digest"))?,
+            input_digest: Digest::parse(row.8)
+                .map_err(|_| corrupt("invalid permit input digest"))?,
+            policy_revision: unsigned(row.9, "policy revision")?,
+            valid_until_ms: unsigned(row.12, "permit deadline")?,
+            single_use: true,
+        },
+        state: parse_permit_state(&row.10)?,
+        consumed_at_ms: row
+            .13
+            .map(|value| unsigned(value, "permit consumption"))
+            .transpose()?,
+        created_at_ms: unsigned(row.14, "permit creation")?,
+    })
+}
+
+fn load_execution(
+    transaction: &rusqlite::Connection,
+    id: &ExecutionId,
+) -> Result<ExecutionRecord, StoreError> {
+    let row = transaction
+        .query_row(
+            "SELECT actor_id, task_id, run_id, target_json, operation_digest, input_digest, state,
+         revision, started_at_ms, completed_at_ms, created_at_ms, updated_at_ms
+         FROM executions WHERE execution_id=?1",
+            params![id.as_str()],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, String>(3)?,
+                    row.get::<_, String>(4)?,
+                    row.get::<_, String>(5)?,
+                    row.get::<_, String>(6)?,
+                    row.get::<_, i64>(7)?,
+                    row.get::<_, Option<i64>>(8)?,
+                    row.get::<_, Option<i64>>(9)?,
+                    row.get::<_, i64>(10)?,
+                    row.get::<_, i64>(11)?,
+                ))
+            },
+        )
+        .optional()?
+        .ok_or_else(|| not_found("execution", id.as_str()))?;
+    let record = ExecutionRecord {
+        execution_id: id.clone(),
+        actor_id: parse_id(&row.0)?,
+        task_id: parse_id(&row.1)?,
+        run_id: parse_id(&row.2)?,
+        target: serde_json::from_str(&row.3)?,
+        operation_digest: Digest::parse(row.4)
+            .map_err(|_| corrupt("invalid execution operation digest"))?,
+        input_digest: Digest::parse(row.5)
+            .map_err(|_| corrupt("invalid execution input digest"))?,
+        state: parse_execution_state(&row.6)?,
+        revision: unsigned(row.7, "execution revision")?,
+        started_at_ms: row
+            .8
+            .map(|value| unsigned(value, "execution start"))
+            .transpose()?,
+        completed_at_ms: row
+            .9
+            .map(|value| unsigned(value, "execution completion"))
+            .transpose()?,
+        created_at_ms: unsigned(row.10, "execution creation")?,
+        updated_at_ms: unsigned(row.11, "execution update")?,
+    };
+    validate_execution_receipt(transaction, &record)?;
+    Ok(record)
+}
+
+fn validate_execution_receipt(
+    transaction: &rusqlite::Connection,
+    execution: &ExecutionRecord,
+) -> Result<(), StoreError> {
+    let receipt = transaction
+        .query_row(
+            "SELECT state FROM execution_receipts WHERE execution_id=?1",
+            params![execution.execution_id.as_str()],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?;
+    let expected = match execution.state {
+        ExecutionState::Succeeded => Some("succeeded"),
+        ExecutionState::Failed => Some("failed"),
+        ExecutionState::Planned | ExecutionState::Started | ExecutionState::Uncertain => None,
+    };
+    if receipt.as_deref() != expected {
+        return Err(corrupt(
+            "execution terminal state and durable receipt are inconsistent",
+        ));
+    }
+    Ok(())
+}
+
+fn validate_all_execution_receipts(transaction: &rusqlite::Connection) -> Result<(), StoreError> {
+    let inconsistent: bool = transaction.query_row(
+        "SELECT EXISTS(
+             SELECT 1 FROM executions e
+             LEFT JOIN execution_receipts r ON r.execution_id=e.execution_id
+             WHERE (e.state='succeeded' AND (r.state IS NULL OR r.state!='succeeded'))
+                OR (e.state='failed' AND (r.state IS NULL OR r.state!='failed'))
+                OR (e.state NOT IN ('succeeded', 'failed') AND r.state IS NOT NULL)
+         )",
+        [],
+        |row| row.get(0),
+    )?;
+    if inconsistent {
+        return Err(corrupt(
+            "execution ledger contains a terminal receipt inconsistency",
+        ));
+    }
+    Ok(())
+}
+
+fn load_runtime_binding(
+    transaction: &rusqlite::Connection,
+    id: &RuntimeBindingId,
+) -> Result<RuntimeBindingRecord, StoreError> {
+    let row = transaction
+        .query_row(
+            "SELECT actor_id, task_id, run_id, runtime_instance_id, runtime_generation,
+         binding_json, state, last_sequence, created_at_ms, updated_at_ms
+         FROM runtime_bindings WHERE binding_id=?1",
+            params![id.as_str()],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, String>(3)?,
+                    row.get::<_, i64>(4)?,
+                    row.get::<_, String>(5)?,
+                    row.get::<_, String>(6)?,
+                    row.get::<_, i64>(7)?,
+                    row.get::<_, i64>(8)?,
+                    row.get::<_, i64>(9)?,
+                ))
+            },
+        )
+        .optional()?
+        .ok_or_else(|| not_found("runtime binding", id.as_str()))?;
+    let binding = serde_json::from_str::<RuntimeBindingRef>(&row.5)?;
+    if binding.binding_id != *id
+        || binding.task_id.as_str() != row.1
+        || binding.run_id.as_str() != row.2
+        || binding.runtime_instance_id.as_str() != row.3
+        || binding.runtime_generation != unsigned(row.4, "runtime generation")?
+    {
+        return Err(corrupt(
+            "runtime binding columns diverge from the versioned binding contract",
+        ));
+    }
+    Ok(RuntimeBindingRecord {
+        binding,
+        actor_id: parse_id(&row.0)?,
+        state: parse_runtime_state(&row.6)?,
+        last_sequence: unsigned(row.7, "runtime sequence")?,
+        created_at_ms: unsigned(row.8, "runtime binding creation")?,
+        updated_at_ms: unsigned(row.9, "runtime binding update")?,
+    })
+}
+
+fn load_run_lease_optional(
+    transaction: &rusqlite::Connection,
+    id: &RunId,
+) -> Result<Option<RunLeaseRecord>, StoreError> {
+    let row = transaction.query_row(
+        "SELECT task_id, actor_id, lease_owner, generation, revision, expires_at_ms, updated_at_ms
+         FROM run_leases WHERE run_id=?1", params![id.as_str()],
+        |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, String>(2)?,
+            row.get::<_, i64>(3)?, row.get::<_, i64>(4)?, row.get::<_, i64>(5)?,
+            row.get::<_, i64>(6)?)),
+    ).optional()?;
+    row.map(|row| {
+        Ok(RunLeaseRecord {
+            task_id: parse_id(&row.0)?,
+            run_id: id.clone(),
+            actor_id: parse_id(&row.1)?,
+            lease_owner: BoundedOpaque::new(row.2).map_err(|_| corrupt("invalid lease owner"))?,
+            generation: unsigned(row.3, "lease generation")?,
+            revision: unsigned(row.4, "lease revision")?,
+            expires_at_ms: unsigned(row.5, "lease deadline")?,
+            updated_at_ms: unsigned(row.6, "lease update")?,
+        })
+    })
+    .transpose()
+}
+
+fn state_name<T: Serialize>(state: T) -> Result<String, StoreError> {
+    serde_json::to_value(state)?
+        .as_str()
+        .map(str::to_owned)
+        .ok_or_else(|| corrupt("ledger state is not serialized as a string"))
+}
+
+fn validate_command(command: &LedgerCommand) -> Result<(), StoreError> {
+    integer(command.committed_at_ms, "ledger timestamp")?;
+    Ok(())
+}
+
+fn next_integer(value: u64, field: &str) -> Result<u64, StoreError> {
+    let next = value
+        .checked_add(1)
+        .ok_or_else(|| conflict(&format!("{field} overflow")))?;
+    integer(next, field)?;
+    Ok(next)
+}
+
+fn require_not_before(now_ms: u64, previous_ms: u64, operation: &str) -> Result<(), StoreError> {
+    if now_ms < previous_ms {
+        Err(conflict(&format!(
+            "{operation} timestamp precedes the durable entity timestamp",
+        )))
+    } else {
+        Ok(())
+    }
+}
+
+fn parse_approval_state(value: &str) -> Result<ApprovalState, StoreError> {
+    parse_state(value)
+}
+fn parse_permit_state(value: &str) -> Result<PermitState, StoreError> {
+    parse_state(value)
+}
+fn parse_execution_state(value: &str) -> Result<ExecutionState, StoreError> {
+    parse_state(value)
+}
+fn parse_runtime_state(value: &str) -> Result<RuntimeBindingState, StoreError> {
+    parse_state(value)
+}
+
+fn parse_state<T: DeserializeOwned>(value: &str) -> Result<T, StoreError> {
+    serde_json::from_value(serde_json::Value::String(value.to_owned())).map_err(StoreError::from)
+}
+
+fn parse_id<T: std::str::FromStr>(value: &str) -> Result<T, StoreError>
+where
+    T::Err: std::fmt::Display,
+{
+    value
+        .parse()
+        .map_err(|error| corrupt(&format!("invalid ledger identity: {error}")))
+}
+
+fn integer(value: u64, field: &str) -> Result<i64, StoreError> {
+    i64::try_from(value).map_err(|_| conflict(&format!("{field} exceeds SQLite INTEGER range")))
+}
+
+fn unsigned(value: i64, field: &str) -> Result<u64, StoreError> {
+    u64::try_from(value).map_err(|_| corrupt(&format!("negative {field}")))
+}
+
+fn conflict(message: &str) -> StoreError {
+    StoreError::LedgerConflict {
+        message: message.to_owned(),
+    }
+}
+
+fn corrupt(message: &str) -> StoreError {
+    StoreError::Corrupt {
+        message: message.to_owned(),
+    }
+}
+
+fn not_found(entity: &str, id: &str) -> StoreError {
+    StoreError::LedgerNotFound {
+        entity: format!("{entity} {id}"),
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/cosh-ng/crates/cosh-gateway/src/storage/ledger/tests.rs
+++ b/src/cosh-ng/crates/cosh-gateway/src/storage/ledger/tests.rs
@@ -1,0 +1,825 @@
+use cosh_gateway_contracts::common::{
+    BoundedName, ContractHeader, ContractSchema, Correlation, RuntimeSelector,
+};
+use cosh_gateway_contracts::external::{ExternalRef, ExternalRefKind};
+use cosh_gateway_contracts::ids::{AgentSessionId, InstallationId, MessageId};
+use cosh_gateway_contracts::task::{TaskEvent, TaskEventEnvelope};
+
+use super::*;
+use crate::storage::{CommitOutcome, TaskCommit};
+
+fn digest(byte: char) -> Digest {
+    Digest::parse(byte.to_string().repeat(64)).unwrap()
+}
+
+fn target() -> TargetRef {
+    TargetRef {
+        kind: BoundedName::new("local").unwrap(),
+        authority: BoundedName::new("test").unwrap(),
+        identifier: BoundedOpaque::new("host").unwrap(),
+    }
+}
+
+fn command(actor_id: &ActorId, key: &str, byte: char, now_ms: u64) -> LedgerCommand {
+    LedgerCommand {
+        actor_id: actor_id.clone(),
+        idempotency_key: IdempotencyKey::new(key).unwrap(),
+        command_digest: digest(byte),
+        committed_at_ms: now_ms,
+    }
+}
+
+fn create_task(store: &mut SqliteTaskStore, actor_id: &ActorId, run_id: &RunId) -> TaskId {
+    let task_id = TaskId::new();
+    let mut correlation = Correlation::new(InstallationId::new());
+    correlation.actor_id = Some(actor_id.clone());
+    correlation.task_id = Some(task_id.clone());
+    let envelope = |revision, event| TaskEventEnvelope {
+        header: ContractHeader::new(
+            ContractSchema::TaskEvent,
+            MessageId::new(),
+            1,
+            correlation.clone(),
+        ),
+        task_id: task_id.clone(),
+        revision,
+        event,
+    };
+    let events = vec![
+        envelope(
+            1,
+            TaskEvent::TaskSubmitted {
+                intent_digest: digest('0'),
+                target: target(),
+            },
+        ),
+        envelope(
+            2,
+            TaskEvent::TaskQueued {
+                run_id: run_id.clone(),
+                runtime: RuntimeSelector {
+                    runtime: BoundedName::new("acp").unwrap(),
+                    profile: Some(BoundedName::new("test").unwrap()),
+                },
+            },
+        ),
+        envelope(
+            3,
+            TaskEvent::RunStarted {
+                run_id: run_id.clone(),
+            },
+        ),
+    ];
+    let outcome = store
+        .commit_task(&TaskCommit {
+            actor_id: actor_id.clone(),
+            idempotency_key: IdempotencyKey::new(format!("task-{}", task_id.as_str())).unwrap(),
+            command_digest: digest('1'),
+            expected_revision: Some(0),
+            events,
+            outbox: Vec::new(),
+            committed_at_ms: 1,
+        })
+        .unwrap();
+    assert!(matches!(outcome, CommitOutcome::Applied(_)));
+    task_id
+}
+
+fn acquire_lease(
+    store: &mut SqliteTaskStore,
+    actor_id: &ActorId,
+    task_id: &TaskId,
+    run_id: &RunId,
+    key: &str,
+    now_ms: u64,
+    expires_at_ms: u64,
+) -> LeaseClaim {
+    let lease = LeaseCommand {
+        command: command(actor_id, key, 'a', now_ms),
+        task_id: task_id.clone(),
+        run_id: run_id.clone(),
+        lease_owner: BoundedOpaque::new(format!("owner-{key}")).unwrap(),
+        expires_at_ms,
+    };
+    let LedgerOutcome::Applied(record) = store.acquire_run_lease(&lease).unwrap() else {
+        panic!("lease must apply")
+    };
+    LeaseClaim {
+        task_id: record.task_id,
+        run_id: record.run_id,
+        lease_owner: record.lease_owner,
+        generation: record.generation,
+        revision: record.revision,
+    }
+}
+
+fn approval(actor_id: &ActorId, task_id: &TaskId, run_id: &RunId) -> ApprovalRecord {
+    ApprovalRecord {
+        approval_id: ApprovalId::new(),
+        request_id: RequestId::new(),
+        actor_id: actor_id.clone(),
+        task_id: task_id.clone(),
+        run_id: run_id.clone(),
+        target: target(),
+        operation_digest: digest('2'),
+        input_digest: digest('3'),
+        state: ApprovalState::Pending,
+        revision: 1,
+        expires_at_ms: 100,
+        decided_by_actor_id: None,
+        created_at_ms: 10,
+        updated_at_ms: 10,
+    }
+}
+
+fn approved_fixture(store: &mut SqliteTaskStore) -> (ActorId, TaskId, RunId, ApprovalRecord) {
+    let actor_id = ActorId::new();
+    let run_id = RunId::new();
+    let task_id = create_task(store, &actor_id, &run_id);
+    let approval = approval(&actor_id, &task_id, &run_id);
+    store
+        .create_approval(&command(&actor_id, "create-approval", '4', 10), &approval)
+        .unwrap();
+    let resolved = store
+        .resolve_approval(
+            &command(&actor_id, "resolve-approval", '5', 20),
+            &approval.approval_id,
+            1,
+            ApprovalResolution::Decide(ApprovalDecision::Approve),
+        )
+        .unwrap();
+    let LedgerOutcome::Applied(approval) = resolved else {
+        panic!("approval must be applied")
+    };
+    (actor_id, task_id, run_id, approval)
+}
+
+fn permit(approval: &ApprovalRecord) -> ExecutionPermit {
+    ExecutionPermit {
+        permit_id: PermitId::new(),
+        request_id: approval.request_id.clone(),
+        actor_id: approval.actor_id.clone(),
+        approval_id: Some(approval.approval_id.clone()),
+        task_id: approval.task_id.clone(),
+        run_id: approval.run_id.clone(),
+        execution_id: ExecutionId::new(),
+        target: approval.target.clone(),
+        operation_digest: approval.operation_digest.clone(),
+        input_digest: approval.input_digest.clone(),
+        policy_revision: 7,
+        valid_until_ms: 90,
+        single_use: true,
+    }
+}
+
+fn claim(permit: &ExecutionPermit, lease: &LeaseClaim) -> ExecutionClaim {
+    ExecutionClaim {
+        permit_id: permit.permit_id.clone(),
+        execution_id: permit.execution_id.clone(),
+        task_id: permit.task_id.clone(),
+        run_id: permit.run_id.clone(),
+        target: permit.target.clone(),
+        operation_digest: permit.operation_digest.clone(),
+        input_digest: permit.input_digest.clone(),
+        policy_revision: permit.policy_revision,
+        lease: lease.clone(),
+    }
+}
+
+#[test]
+fn approval_resolution_is_actor_revision_deadline_and_idempotency_bound() {
+    let mut store = SqliteTaskStore::open_in_memory().unwrap();
+    let actor_id = ActorId::new();
+    let run_id = RunId::new();
+    let task_id = create_task(&mut store, &actor_id, &run_id);
+    let approval = approval(&actor_id, &task_id, &run_id);
+    let create = command(&actor_id, "create", '6', 10);
+
+    assert!(matches!(
+        store.create_approval(&create, &approval).unwrap(),
+        LedgerOutcome::Applied(_)
+    ));
+    assert!(matches!(
+        store.create_approval(&create, &approval).unwrap(),
+        LedgerOutcome::Replayed(_)
+    ));
+    let attacker = ActorId::new();
+    assert!(matches!(
+        store.resolve_approval(
+            &command(&attacker, "attack", '7', 20),
+            &approval.approval_id,
+            1,
+            ApprovalResolution::Decide(ApprovalDecision::Approve)
+        ),
+        Err(StoreError::LedgerConflict { .. })
+    ));
+    let expired = store
+        .resolve_approval(
+            &command(&actor_id, "late", '8', 100),
+            &approval.approval_id,
+            1,
+            ApprovalResolution::Decide(ApprovalDecision::Approve),
+        )
+        .unwrap();
+    let LedgerOutcome::Applied(expired) = expired else {
+        panic!("deadline transition must be applied")
+    };
+    assert_eq!(expired.state, ApprovalState::Expired);
+    assert!(expired.decided_by_actor_id.is_none());
+}
+
+#[test]
+fn permit_consumption_and_execution_start_are_atomic_and_exactly_bound() {
+    let mut store = SqliteTaskStore::open_in_memory().unwrap();
+    let (actor_id, task_id, run_id, approval) = approved_fixture(&mut store);
+    let lease = acquire_lease(
+        &mut store,
+        &actor_id,
+        &task_id,
+        &run_id,
+        "lease-consume",
+        25,
+        80,
+    );
+    let permit = permit(&approval);
+    store
+        .issue_permit(&command(&actor_id, "issue", '9', 30), &permit)
+        .unwrap();
+
+    let exact = claim(&permit, &lease);
+    let mut substitutions = Vec::new();
+    let mut task = exact.clone();
+    task.task_id = TaskId::new();
+    substitutions.push(task);
+    let mut run = exact.clone();
+    run.run_id = RunId::new();
+    substitutions.push(run);
+    let mut changed_target = exact.clone();
+    changed_target.target = TargetRef {
+        kind: BoundedName::new("local").unwrap(),
+        authority: BoundedName::new("test").unwrap(),
+        identifier: BoundedOpaque::new("other-host").unwrap(),
+    };
+    substitutions.push(changed_target);
+    let mut operation = exact.clone();
+    operation.operation_digest = digest('a');
+    substitutions.push(operation);
+    let mut input = exact.clone();
+    input.input_digest = digest('b');
+    substitutions.push(input);
+    let mut execution = exact.clone();
+    execution.execution_id = ExecutionId::new();
+    substitutions.push(execution);
+    for (index, substituted) in substitutions.iter().enumerate() {
+        let result = store.consume_permit_and_start_execution(
+            &command(
+                &actor_id,
+                &format!("substitute-{index}"),
+                char::from_digit(u32::try_from(index + 1).unwrap(), 10).unwrap(),
+                40,
+            ),
+            substituted,
+        );
+        assert!(result.is_err(), "substitution {index} must fail closed");
+    }
+    let attacker = ActorId::new();
+    assert!(store
+        .consume_permit_and_start_execution(
+            &command(&attacker, "substitute-actor", '7', 40),
+            &exact,
+        )
+        .is_err());
+    let permit_state: String = store
+        .connection()
+        .query_row(
+            "SELECT state FROM permits WHERE permit_id=?1",
+            params![permit.permit_id.as_str()],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let execution_state: String = store
+        .connection()
+        .query_row(
+            "SELECT state FROM executions WHERE execution_id=?1",
+            params![permit.execution_id.as_str()],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        (permit_state.as_str(), execution_state.as_str()),
+        ("issued", "planned")
+    );
+
+    let started = store
+        .consume_permit_and_start_execution(&command(&actor_id, "consume", 'b', 40), &exact)
+        .unwrap();
+    let LedgerOutcome::Applied(started) = started else {
+        panic!("consumption must apply")
+    };
+    assert_eq!(started.state, ExecutionState::Started);
+    assert_eq!(started.revision, 2);
+    assert!(matches!(
+        store.consume_permit_and_start_execution(
+            &command(&actor_id, "reuse", 'c', 41),
+            &claim(&permit, &lease)
+        ),
+        Err(StoreError::LedgerConflict { .. })
+    ));
+}
+
+#[test]
+fn completion_is_revisioned_and_persists_one_evidence_receipt() {
+    let mut store = SqliteTaskStore::open_in_memory().unwrap();
+    let (actor_id, task_id, run_id, approval) = approved_fixture(&mut store);
+    let lease = acquire_lease(
+        &mut store,
+        &actor_id,
+        &task_id,
+        &run_id,
+        "lease-complete",
+        25,
+        80,
+    );
+    let permit = permit(&approval);
+    store
+        .issue_permit(&command(&actor_id, "issue", 'd', 30), &permit)
+        .unwrap();
+    store
+        .consume_permit_and_start_execution(
+            &command(&actor_id, "consume", 'e', 40),
+            &claim(&permit, &lease),
+        )
+        .unwrap();
+    let completion = ExecutionCompletion {
+        execution_id: permit.execution_id.clone(),
+        expected_revision: 2,
+        succeeded: true,
+        receipt_digest: digest('f'),
+        safe_detail: Some(BoundedText::new("completed").unwrap()),
+    };
+    let completed = store
+        .complete_execution(&command(&actor_id, "complete", 'f', 50), &completion)
+        .unwrap();
+    let LedgerOutcome::Applied(completed) = completed else {
+        panic!("must apply")
+    };
+    assert_eq!(completed.state, ExecutionState::Succeeded);
+    let receipt_count: i64 = store
+        .connection()
+        .query_row(
+            "SELECT COUNT(*) FROM execution_receipts WHERE execution_id=?1",
+            params![permit.execution_id.as_str()],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(receipt_count, 1);
+}
+
+#[test]
+fn recovery_marks_started_execution_uncertain_without_retry() {
+    let mut store = SqliteTaskStore::open_in_memory().unwrap();
+    let (actor_id, task_id, run_id, approval) = approved_fixture(&mut store);
+    let lease = acquire_lease(&mut store, &actor_id, &task_id, &run_id, "recover", 25, 80);
+    let permit = permit(&approval);
+    store
+        .issue_permit(&command(&actor_id, "issue", '1', 30), &permit)
+        .unwrap();
+    store
+        .consume_permit_and_start_execution(
+            &command(&actor_id, "consume", '2', 40),
+            &claim(&permit, &lease),
+        )
+        .unwrap();
+
+    let report = store.recover_gateway(60).unwrap();
+    assert_eq!(report.executions_uncertain, 1);
+    let state: String = store
+        .connection()
+        .query_row(
+            "SELECT state FROM executions WHERE execution_id=?1",
+            params![permit.execution_id.as_str()],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(state, "uncertain");
+    let receipts: i64 = store
+        .connection()
+        .query_row(
+            "SELECT COUNT(*) FROM execution_receipts WHERE execution_id=?1",
+            params![permit.execution_id.as_str()],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(receipts, 0);
+}
+
+fn runtime_binding(task_id: &TaskId, run_id: &RunId, generation: u64) -> RuntimeBindingRef {
+    RuntimeBindingRef {
+        binding_id: RuntimeBindingId::new(),
+        task_id: task_id.clone(),
+        run_id: run_id.clone(),
+        agent_session_id: AgentSessionId::new(),
+        runtime_instance_id: RuntimeInstanceId::new(),
+        runtime_generation: generation,
+        external_session: ExternalRef {
+            kind: ExternalRefKind::AcpSession,
+            authority: BoundedName::new("test").unwrap(),
+            scope_digest: digest('3'),
+            value: BoundedOpaque::new("session").unwrap(),
+        },
+    }
+}
+
+#[test]
+fn runtime_generation_and_sequence_fence_stale_output() {
+    let mut store = SqliteTaskStore::open_in_memory().unwrap();
+    let actor_id = ActorId::new();
+    let run_id = RunId::new();
+    let task_id = create_task(&mut store, &actor_id, &run_id);
+    let lease = acquire_lease(&mut store, &actor_id, &task_id, &run_id, "runtime", 5, 100);
+    let first = runtime_binding(&task_id, &run_id, 1);
+    store
+        .bind_runtime(&command(&actor_id, "bind-1", '4', 10), &first, &lease)
+        .unwrap();
+    store
+        .record_runtime_sequence(
+            &first.binding_id,
+            &first.runtime_instance_id,
+            1,
+            1,
+            11,
+            &lease,
+        )
+        .unwrap();
+    assert!(matches!(
+        store.record_runtime_sequence(
+            &first.binding_id,
+            &first.runtime_instance_id,
+            1,
+            1,
+            12,
+            &lease,
+        ),
+        Err(StoreError::LedgerConflict { .. })
+    ));
+    let second = runtime_binding(&task_id, &run_id, 2);
+    store
+        .bind_runtime(&command(&actor_id, "bind-2", '5', 20), &second, &lease)
+        .unwrap();
+    assert!(matches!(
+        store.record_runtime_sequence(
+            &first.binding_id,
+            &first.runtime_instance_id,
+            1,
+            2,
+            21,
+            &lease,
+        ),
+        Err(StoreError::LedgerConflict { .. })
+    ));
+    let stale_generation = runtime_binding(&task_id, &run_id, 1);
+    assert!(matches!(
+        store.bind_runtime(
+            &command(&actor_id, "stale", '6', 21),
+            &stale_generation,
+            &lease,
+        ),
+        Err(StoreError::GenerationFenced { .. })
+    ));
+}
+
+#[test]
+fn expired_run_lease_takeover_increments_fencing_generation() {
+    let mut store = SqliteTaskStore::open_in_memory().unwrap();
+    let actor_id = ActorId::new();
+    let run_id = RunId::new();
+    let task_id = create_task(&mut store, &actor_id, &run_id);
+    let first = LeaseCommand {
+        command: command(&actor_id, "lease-1", '7', 10),
+        task_id: task_id.clone(),
+        run_id: run_id.clone(),
+        lease_owner: BoundedOpaque::new("coordinator-a").unwrap(),
+        expires_at_ms: 20,
+    };
+    let LedgerOutcome::Applied(first_record) = store.acquire_run_lease(&first).unwrap() else {
+        panic!("first lease must apply")
+    };
+    assert_eq!(first_record.generation, 1);
+    let renewal = LeaseCommand {
+        command: command(&actor_id, "lease-renew", 'a', 12),
+        task_id: task_id.clone(),
+        run_id: run_id.clone(),
+        lease_owner: BoundedOpaque::new("coordinator-a").unwrap(),
+        expires_at_ms: 22,
+    };
+    let LedgerOutcome::Applied(renewed) = store
+        .renew_run_lease(&renewal, first_record.generation, first_record.revision)
+        .unwrap()
+    else {
+        panic!("renewal must apply")
+    };
+    assert_eq!(renewed.generation, 1);
+    assert_eq!(renewed.revision, 2);
+    let held = LeaseCommand {
+        command: command(&actor_id, "lease-held", '8', 21),
+        task_id: task_id.clone(),
+        run_id: run_id.clone(),
+        lease_owner: BoundedOpaque::new("coordinator-b").unwrap(),
+        expires_at_ms: 30,
+    };
+    assert!(matches!(
+        store.acquire_run_lease(&held),
+        Err(StoreError::LedgerConflict { .. })
+    ));
+    let takeover = LeaseCommand {
+        command: command(&actor_id, "lease-2", '9', 22),
+        task_id,
+        run_id,
+        lease_owner: BoundedOpaque::new("coordinator-b").unwrap(),
+        expires_at_ms: 30,
+    };
+    let LedgerOutcome::Applied(second_record) = store.acquire_run_lease(&takeover).unwrap() else {
+        panic!("takeover must apply")
+    };
+    assert_eq!(second_record.generation, 2);
+    assert_eq!(second_record.revision, 3);
+    assert_eq!(
+        store.load_run_lease(&second_record.run_id).unwrap(),
+        second_record
+    );
+}
+
+#[test]
+fn released_run_lease_can_be_reacquired_only_with_a_new_generation() {
+    let mut store = SqliteTaskStore::open_in_memory().unwrap();
+    let actor_id = ActorId::new();
+    let run_id = RunId::new();
+    let task_id = create_task(&mut store, &actor_id, &run_id);
+    let acquired = LeaseCommand {
+        command: command(&actor_id, "lease-acquire", 'b', 10),
+        task_id: task_id.clone(),
+        run_id: run_id.clone(),
+        lease_owner: BoundedOpaque::new("coordinator-a").unwrap(),
+        expires_at_ms: 30,
+    };
+    let LedgerOutcome::Applied(first) = store.acquire_run_lease(&acquired).unwrap() else {
+        panic!("lease must apply")
+    };
+    let released = store
+        .release_run_lease(
+            &command(&actor_id, "lease-release", 'c', 15),
+            &LeaseClaim {
+                task_id: task_id.clone(),
+                run_id: run_id.clone(),
+                lease_owner: first.lease_owner,
+                generation: first.generation,
+                revision: first.revision,
+            },
+        )
+        .unwrap();
+    let LedgerOutcome::Applied(released) = released else {
+        panic!("release must apply")
+    };
+    assert_eq!(released.expires_at_ms, 15);
+    let reacquire = LeaseCommand {
+        command: command(&actor_id, "lease-reacquire", 'd', 15),
+        task_id,
+        run_id,
+        lease_owner: BoundedOpaque::new("coordinator-b").unwrap(),
+        expires_at_ms: 40,
+    };
+    let LedgerOutcome::Applied(second) = store.acquire_run_lease(&reacquire).unwrap() else {
+        panic!("reacquire must apply")
+    };
+    assert_eq!(second.generation, 2);
+}
+
+#[test]
+fn stale_lease_and_cross_task_run_claims_roll_back_atomically() {
+    let mut store = SqliteTaskStore::open_in_memory().unwrap();
+    let (actor_id, task_id, run_id, approval) = approved_fixture(&mut store);
+    let stale = acquire_lease(
+        &mut store,
+        &actor_id,
+        &task_id,
+        &run_id,
+        "lease-stale",
+        25,
+        70,
+    );
+    let renewal = LeaseCommand {
+        command: command(&actor_id, "renew-stale", '2', 30),
+        task_id: task_id.clone(),
+        run_id: run_id.clone(),
+        lease_owner: stale.lease_owner.clone(),
+        expires_at_ms: 80,
+    };
+    store
+        .renew_run_lease(&renewal, stale.generation, stale.revision)
+        .unwrap();
+    let permit = permit(&approval);
+    store
+        .issue_permit(&command(&actor_id, "issue-stale", '3', 35), &permit)
+        .unwrap();
+
+    assert!(matches!(
+        store.consume_permit_and_start_execution(
+            &command(&actor_id, "consume-stale", '4', 40),
+            &claim(&permit, &stale),
+        ),
+        Err(StoreError::LedgerConflict { .. })
+    ));
+
+    let other_run = RunId::new();
+    let _other_task = create_task(&mut store, &actor_id, &other_run);
+    let mut substituted = claim(&permit, &stale);
+    substituted.run_id = other_run;
+    assert!(matches!(
+        store.consume_permit_and_start_execution(
+            &command(&actor_id, "consume-other-run", '5', 40),
+            &substituted,
+        ),
+        Err(StoreError::LedgerConflict { .. })
+    ));
+
+    let states = store
+        .connection()
+        .query_row(
+            "SELECT p.state, e.state FROM permits p JOIN executions e
+             ON e.execution_id=p.execution_id WHERE p.permit_id=?1",
+            params![permit.permit_id.as_str()],
+            |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)),
+        )
+        .unwrap();
+    assert_eq!(states, ("issued".to_owned(), "planned".to_owned()));
+}
+
+#[test]
+fn permit_deadline_cannot_outlive_approval_and_overflow_rolls_back() {
+    let mut store = SqliteTaskStore::open_in_memory().unwrap();
+    let (actor_id, task_id, run_id, approved) = approved_fixture(&mut store);
+    let mut widened = permit(&approved);
+    widened.valid_until_ms = approved.expires_at_ms + 1;
+    assert!(matches!(
+        store.issue_permit(&command(&actor_id, "issue-wide", '6', 30), &widened),
+        Err(StoreError::LedgerConflict { .. })
+    ));
+
+    let mut overflow = approval(&actor_id, &task_id, &run_id);
+    overflow.approval_id = ApprovalId::new();
+    overflow.request_id = RequestId::new();
+    overflow.expires_at_ms = u64::MAX;
+    assert!(matches!(
+        store.create_approval(&command(&actor_id, "create-overflow", '7', 40), &overflow,),
+        Err(StoreError::LedgerConflict { .. })
+    ));
+
+    let (permits, executions, approvals): (i64, i64, i64) = store
+        .connection()
+        .query_row(
+            "SELECT (SELECT COUNT(*) FROM permits),
+                    (SELECT COUNT(*) FROM executions),
+                    (SELECT COUNT(*) FROM approvals WHERE approval_id=?1)",
+            params![overflow.approval_id.as_str()],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .unwrap();
+    assert_eq!((permits, executions, approvals), (0, 0, 0));
+}
+
+#[test]
+fn runtime_acceptance_requires_current_lease_and_exact_next_generation() {
+    let mut store = SqliteTaskStore::open_in_memory().unwrap();
+    let actor_id = ActorId::new();
+    let run_id = RunId::new();
+    let task_id = create_task(&mut store, &actor_id, &run_id);
+    let stale = acquire_lease(
+        &mut store,
+        &actor_id,
+        &task_id,
+        &run_id,
+        "runtime-stale",
+        5,
+        30,
+    );
+    let first = runtime_binding(&task_id, &run_id, 1);
+    store
+        .bind_runtime(&command(&actor_id, "bind-first", '8', 10), &first, &stale)
+        .unwrap();
+    let skipped = runtime_binding(&task_id, &run_id, 3);
+    assert!(matches!(
+        store.bind_runtime(&command(&actor_id, "bind-skip", '9', 11), &skipped, &stale,),
+        Err(StoreError::GenerationFenced {
+            expected: 2,
+            actual: 3
+        })
+    ));
+
+    let renewal = LeaseCommand {
+        command: command(&actor_id, "runtime-renew", 'a', 12),
+        task_id: task_id.clone(),
+        run_id: run_id.clone(),
+        lease_owner: stale.lease_owner.clone(),
+        expires_at_ms: 40,
+    };
+    store
+        .renew_run_lease(&renewal, stale.generation, stale.revision)
+        .unwrap();
+    assert!(matches!(
+        store.record_runtime_sequence(
+            &first.binding_id,
+            &first.runtime_instance_id,
+            1,
+            1,
+            13,
+            &stale,
+        ),
+        Err(StoreError::LedgerConflict { .. })
+    ));
+    assert_eq!(
+        store
+            .load_runtime_binding_record(&first.binding_id)
+            .unwrap()
+            .last_sequence,
+        0
+    );
+}
+
+#[test]
+fn terminal_receipt_corruption_fails_load_and_recovery_without_mutation() {
+    let mut store = SqliteTaskStore::open_in_memory().unwrap();
+    let (actor_id, task_id, run_id, approval) = approved_fixture(&mut store);
+    let lease = acquire_lease(
+        &mut store,
+        &actor_id,
+        &task_id,
+        &run_id,
+        "receipt-corrupt",
+        25,
+        80,
+    );
+    let permit = permit(&approval);
+    store
+        .issue_permit(&command(&actor_id, "issue-receipt", 'b', 30), &permit)
+        .unwrap();
+    store
+        .consume_permit_and_start_execution(
+            &command(&actor_id, "consume-receipt", 'c', 40),
+            &claim(&permit, &lease),
+        )
+        .unwrap();
+    store
+        .complete_execution(
+            &command(&actor_id, "complete-receipt", 'd', 50),
+            &ExecutionCompletion {
+                execution_id: permit.execution_id.clone(),
+                expected_revision: 2,
+                succeeded: true,
+                receipt_digest: digest('e'),
+                safe_detail: None,
+            },
+        )
+        .unwrap();
+    store
+        .connection()
+        .execute(
+            "UPDATE execution_receipts SET state='failed' WHERE execution_id=?1",
+            params![permit.execution_id.as_str()],
+        )
+        .unwrap();
+
+    assert!(matches!(
+        store.load_execution_record(&permit.execution_id),
+        Err(StoreError::Corrupt { .. })
+    ));
+    assert!(matches!(
+        store.recover_gateway(60),
+        Err(StoreError::Corrupt { .. })
+    ));
+    let state: String = store
+        .connection()
+        .query_row(
+            "SELECT state FROM executions WHERE execution_id=?1",
+            params![permit.execution_id.as_str()],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(state, "succeeded");
+}
+
+#[test]
+fn task_and_ledger_commands_share_one_idempotency_namespace() {
+    let mut store = SqliteTaskStore::open_in_memory().unwrap();
+    let actor_id = ActorId::new();
+    let run_id = RunId::new();
+    let task_id = create_task(&mut store, &actor_id, &run_id);
+    let approval = approval(&actor_id, &task_id, &run_id);
+    let task_key = format!("task-{}", task_id.as_str());
+    let result = store.create_approval(&command(&actor_id, &task_key, 'f', 10), &approval);
+    assert!(matches!(result, Err(StoreError::IdempotencyConflict)));
+    let count: i64 = store
+        .connection()
+        .query_row("SELECT COUNT(*) FROM approvals", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(count, 0);
+}

--- a/src/cosh-ng/crates/cosh-gateway/src/storage/schema.rs
+++ b/src/cosh-ng/crates/cosh-gateway/src/storage/schema.rs
@@ -4,7 +4,7 @@ use rusqlite::{params, Connection, OptionalExtension, Transaction};
 
 use super::StoreError;
 
-pub(super) const CURRENT_SCHEMA_VERSION: u32 = 1;
+pub(super) const CURRENT_SCHEMA_VERSION: u32 = 2;
 
 struct Migration {
     version: u32,
@@ -12,10 +12,11 @@ struct Migration {
     sql: &'static str,
 }
 
-const MIGRATIONS: &[Migration] = &[Migration {
-    version: 1,
-    checksum: "cosh-gateway-task-schema-v1-20260813-causation-nullable",
-    sql: r#"
+const MIGRATIONS: &[Migration] = &[
+    Migration {
+        version: 1,
+        checksum: "cosh-gateway-task-schema-v1-20260813-causation-nullable",
+        sql: r#"
 CREATE TABLE tasks (
     task_id TEXT PRIMARY KEY NOT NULL,
     owner_actor_id TEXT NOT NULL,
@@ -73,7 +74,143 @@ CREATE INDEX task_events_task_revision
 CREATE INDEX outbox_ready
     ON outbox(state, next_attempt_at_ms, created_at_ms);
 "#,
-}];
+    },
+    Migration {
+        version: 2,
+        checksum: "cosh-gateway-ledger-schema-v2-20260814-fenced",
+        sql: r#"
+CREATE TABLE ledger_receipts (
+    actor_id TEXT NOT NULL,
+    idempotency_key TEXT NOT NULL,
+    command_digest TEXT NOT NULL,
+    operation TEXT NOT NULL,
+    result_json TEXT NOT NULL,
+    committed_at_ms INTEGER NOT NULL CHECK (committed_at_ms >= 0),
+    PRIMARY KEY(actor_id, idempotency_key)
+) STRICT;
+
+CREATE TABLE approvals (
+    approval_id TEXT PRIMARY KEY NOT NULL,
+    request_id TEXT NOT NULL UNIQUE,
+    actor_id TEXT NOT NULL,
+    task_id TEXT NOT NULL REFERENCES tasks(task_id) ON DELETE RESTRICT,
+    run_id TEXT NOT NULL,
+    target_json TEXT NOT NULL,
+    operation_digest TEXT NOT NULL,
+    input_digest TEXT NOT NULL,
+    state TEXT NOT NULL CHECK (
+        state IN ('pending', 'approved', 'denied', 'expired', 'cancelled')
+    ),
+    revision INTEGER NOT NULL CHECK (revision > 0),
+    expires_at_ms INTEGER NOT NULL CHECK (expires_at_ms >= 0),
+    decided_by_actor_id TEXT,
+    created_at_ms INTEGER NOT NULL CHECK (created_at_ms >= 0),
+    updated_at_ms INTEGER NOT NULL CHECK (updated_at_ms >= created_at_ms),
+    CHECK ((state IN ('approved', 'denied')) = (decided_by_actor_id IS NOT NULL))
+) STRICT;
+
+CREATE TABLE executions (
+    execution_id TEXT PRIMARY KEY NOT NULL,
+    actor_id TEXT NOT NULL,
+    task_id TEXT NOT NULL REFERENCES tasks(task_id) ON DELETE RESTRICT,
+    run_id TEXT NOT NULL,
+    target_json TEXT NOT NULL,
+    operation_digest TEXT NOT NULL,
+    input_digest TEXT NOT NULL,
+    state TEXT NOT NULL CHECK (
+        state IN ('planned', 'started', 'succeeded', 'failed', 'uncertain')
+    ),
+    revision INTEGER NOT NULL CHECK (revision > 0),
+    started_at_ms INTEGER,
+    completed_at_ms INTEGER,
+    created_at_ms INTEGER NOT NULL CHECK (created_at_ms >= 0),
+    updated_at_ms INTEGER NOT NULL CHECK (updated_at_ms >= created_at_ms),
+    CHECK ((state = 'planned') = (started_at_ms IS NULL)),
+    CHECK ((state IN ('succeeded', 'failed', 'uncertain')) = (completed_at_ms IS NOT NULL))
+) STRICT;
+
+CREATE TABLE permits (
+    permit_id TEXT PRIMARY KEY NOT NULL,
+    request_id TEXT NOT NULL UNIQUE,
+    approval_id TEXT REFERENCES approvals(approval_id) ON DELETE RESTRICT,
+    actor_id TEXT NOT NULL,
+    task_id TEXT NOT NULL REFERENCES tasks(task_id) ON DELETE RESTRICT,
+    run_id TEXT NOT NULL,
+    execution_id TEXT NOT NULL UNIQUE REFERENCES executions(execution_id) ON DELETE RESTRICT,
+    target_json TEXT NOT NULL,
+    operation_digest TEXT NOT NULL,
+    input_digest TEXT NOT NULL,
+    policy_revision INTEGER NOT NULL CHECK (policy_revision >= 0),
+    state TEXT NOT NULL CHECK (state IN ('issued', 'consumed', 'expired', 'revoked')),
+    single_use INTEGER NOT NULL CHECK (single_use = 1),
+    valid_until_ms INTEGER NOT NULL CHECK (valid_until_ms >= 0),
+    consumed_at_ms INTEGER,
+    created_at_ms INTEGER NOT NULL CHECK (created_at_ms >= 0),
+    CHECK ((state = 'consumed') = (consumed_at_ms IS NOT NULL))
+) STRICT;
+
+CREATE TABLE execution_receipts (
+    execution_id TEXT PRIMARY KEY NOT NULL REFERENCES executions(execution_id) ON DELETE RESTRICT,
+    state TEXT NOT NULL CHECK (state IN ('succeeded', 'failed')),
+    receipt_digest TEXT NOT NULL,
+    safe_detail TEXT,
+    committed_at_ms INTEGER NOT NULL CHECK (committed_at_ms >= 0)
+) STRICT;
+
+CREATE TABLE runtime_bindings (
+    binding_id TEXT PRIMARY KEY NOT NULL,
+    actor_id TEXT NOT NULL,
+    task_id TEXT NOT NULL REFERENCES tasks(task_id) ON DELETE RESTRICT,
+    run_id TEXT NOT NULL,
+    runtime_instance_id TEXT NOT NULL,
+    runtime_generation INTEGER NOT NULL CHECK (runtime_generation > 0),
+    binding_json TEXT NOT NULL,
+    state TEXT NOT NULL CHECK (state IN ('active', 'closed', 'lost')),
+    last_sequence INTEGER NOT NULL DEFAULT 0 CHECK (last_sequence >= 0),
+    created_at_ms INTEGER NOT NULL CHECK (created_at_ms >= 0),
+    updated_at_ms INTEGER NOT NULL CHECK (updated_at_ms >= created_at_ms),
+    UNIQUE(run_id, runtime_generation)
+) STRICT;
+
+CREATE TABLE run_leases (
+    run_id TEXT PRIMARY KEY NOT NULL,
+    task_id TEXT NOT NULL REFERENCES tasks(task_id) ON DELETE RESTRICT,
+    actor_id TEXT NOT NULL,
+    lease_owner TEXT NOT NULL,
+    generation INTEGER NOT NULL CHECK (generation > 0),
+    revision INTEGER NOT NULL CHECK (revision > 0),
+    expires_at_ms INTEGER NOT NULL CHECK (expires_at_ms >= 0),
+    updated_at_ms INTEGER NOT NULL CHECK (updated_at_ms >= 0)
+) STRICT;
+
+CREATE INDEX approvals_pending ON approvals(state, expires_at_ms);
+CREATE INDEX permits_issued ON permits(state, valid_until_ms);
+CREATE INDEX executions_recovery ON executions(state, updated_at_ms);
+CREATE INDEX runtime_bindings_run ON runtime_bindings(run_id, state);
+CREATE INDEX run_leases_expiry ON run_leases(expires_at_ms);
+
+CREATE TRIGGER command_receipts_reserve_idempotency_namespace
+BEFORE INSERT ON command_receipts
+WHEN EXISTS (
+    SELECT 1 FROM ledger_receipts
+    WHERE actor_id = NEW.actor_id AND idempotency_key = NEW.idempotency_key
+)
+BEGIN
+    SELECT RAISE(ABORT, 'idempotency namespace conflict');
+END;
+
+CREATE TRIGGER ledger_receipts_reserve_idempotency_namespace
+BEFORE INSERT ON ledger_receipts
+WHEN EXISTS (
+    SELECT 1 FROM command_receipts
+    WHERE actor_id = NEW.actor_id AND idempotency_key = NEW.idempotency_key
+)
+BEGIN
+    SELECT RAISE(ABORT, 'idempotency namespace conflict');
+END;
+"#,
+    },
+];
 
 pub(super) fn migrate(connection: &mut Connection) -> Result<(), StoreError> {
     connection.execute_batch(
@@ -174,13 +311,55 @@ mod tests {
         assert_eq!(
             tables,
             [
+                "approvals",
                 "command_receipts",
+                "execution_receipts",
+                "executions",
+                "ledger_receipts",
                 "outbox",
+                "permits",
+                "run_leases",
+                "runtime_bindings",
                 "schema_migrations",
                 "task_events",
                 "tasks"
             ]
         );
+    }
+
+    #[test]
+    fn existing_v1_database_migrates_to_v2_without_rewriting_v1() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        connection
+            .execute_batch(
+                "PRAGMA foreign_keys = ON;
+                 CREATE TABLE schema_migrations (
+                     version INTEGER PRIMARY KEY NOT NULL CHECK (version > 0),
+                     checksum TEXT NOT NULL,
+                     applied_at_ms INTEGER NOT NULL CHECK (applied_at_ms >= 0)
+                 ) STRICT;",
+            )
+            .unwrap();
+        apply_migration(&mut connection, &MIGRATIONS[0]).unwrap();
+
+        migrate(&mut connection).unwrap();
+
+        let versions = connection
+            .prepare("SELECT version FROM schema_migrations ORDER BY version")
+            .unwrap()
+            .query_map([], |row| row.get::<_, u32>(0))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(versions, [1, 2]);
+        let v1_checksum: String = connection
+            .query_row(
+                "SELECT checksum FROM schema_migrations WHERE version=1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(v1_checksum, MIGRATIONS[0].checksum);
     }
 
     #[test]

--- a/src/cosh-ng/docs/design/acp-v1-phase-0-2/phase-1/capability-broker/acceptance.md
+++ b/src/cosh-ng/docs/design/acp-v1-phase-0-2/phase-1/capability-broker/acceptance.md
@@ -19,6 +19,25 @@ fence, durable permit/execution ledger, audit gate, OS executor, revocation, cra
 reconciliation, network API, or ACP integration. Existing CLI/Core/Shell mutation paths still
 bypass this slice.
 
+## Durable ledger storage result
+
+**Overall: VERIFIED DURABLE STORAGE SLICE; BROKER INTEGRATION REMAINS PARTIAL.** A checksummed
+SQLite v2 migration now stores approval resolution, single-use permits, execution state and
+receipts, Runtime bindings, and fenced Run leases. The durable consume path replays the
+authoritative Task event stream, requires the exact current lease claim, atomically changes an
+issued permit and planned execution to consumed/started, and marks an unreceipted started execution
+`uncertain` during recovery without retrying the effect. Approved permits cannot outlive or widen
+their approval bindings.
+
+`cargo +1.88.0 test --locked --package cosh-gateway storage --no-fail-fast` passed 28/28 targeted
+storage tests on 2026-08-13. These tests include stale-lease, cross-Task Run, generation-skip,
+approval-deadline widening, integer-overflow, idempotency-namespace, receipt-corruption, and atomic
+rollback fixtures.
+
+The process-local `CapabilityBroker` is not yet wired to this store, so existing bypass findings,
+immutable target resolution, required audit persistence, the OS executor, and reconciliation remain
+open.
+
 ## Result vocabulary
 
 | Result | Meaning |
@@ -50,12 +69,12 @@ Runtime bridges, OS operators, ACP, or network APIs.
 | CBR-002 | Target resolves to an immutable authenticated identity. | NOT IMPLEMENTED | The first slice binds exact `TargetRef`; there is no resolver, boot/workspace/UID identity, or attestation. |
 | CBR-003 | Policy result, approval, and permit are distinct types. | PARTIAL | `PolicyDecision`, `ApprovalRequest`, `CapabilityDecision`, and `ExecutionPermit` are distinct; durable approval resolution/re-authorization is absent. |
 | CBR-004 | Every permitted effect has one `ExecutionId`. | PARTIAL | Every Broker-issued permit gets one `ExecutionId`; bypass paths and execution lifecycle are not integrated. |
-| CBR-005 | Permit binds actor, Task, Run, target, operation digest, policy, fence, expiry, and one use. | PARTIAL | Actor/Task/Run/Execution/exact target/complete operation digest/policy/expiry/single-use bindings pass; immutable target and runtime/lease fence remain. Canonicalization and hashing still rely on trusted ingress. |
-| CBR-006 | Target verifies and consumes permit immediately before execution. | PARTIAL | `claim` atomically verifies and consumes, but no target adapter or durable store invokes it before an effect. |
-| CBR-007 | Approval is durable Task state and cannot widen authority. | PARTIAL | Approval requests preserve request/Task/Run/expiry; there is no durable approval ledger, resolution, or approval-bound issuance. Direct permits have `approval_id = None`. |
+| CBR-005 | Permit binds actor, Task, Run, target, operation digest, policy, fence, expiry, and one use. | PARTIAL | Durable consume verifies exact actor/Task/authoritative Run/Execution/target/digests/policy/expiry plus current lease generation and revision. Immutable target identity and production Broker wiring remain. |
+| CBR-006 | Target verifies and consumes permit immediately before execution. | PARTIAL | Durable consume and execution start are one transaction, but no OS target adapter invokes the ledger immediately before an effect. |
+| CBR-007 | Approval is durable Task state and cannot widen authority. | PARTIAL | Durable approval resolution and exact approval-bound issuance exist; the approval ledger is not yet atomically integrated with Task approval events. Direct policy permits remain supported. |
 | CBR-008 | Broker never writes the Task aggregate. | PASS | Broker has no Task aggregate or storage dependency and returns decisions only. |
-| CBR-009 | Repeated execute cannot produce a second effect. | PARTIAL | One of eight concurrent claims wins and replay fails in one process; there is no durable execution/effect ledger across restart. |
-| CBR-010 | Crash uncertainty triggers typed reconciliation, never automatic retry. | NOT IMPLEMENTED | No execution lifecycle or reconciliation port exists. |
+| CBR-009 | Repeated execute cannot produce a second effect. | PARTIAL | Durable single-use consume and idempotent command receipts survive restart; executor integration must still prove that `Replayed` outcomes never repeat an effect. |
+| CBR-010 | Crash uncertainty triggers typed reconciliation, never automatic retry. | PARTIAL | Recovery changes every unreceipted started execution to `uncertain` without retry; a typed reconciliation port is absent. |
 | CBR-011 | Shell parsing fails closed on adversarial separators and metacharacters. | PASS | Existing parser/heuristic baseline remains reusable; the new Broker does not add a Shell fallback. |
 | CBR-012 | Typed policy has allow/deny/require-approval outcomes. | PASS | Neutral `PolicyPort` and deterministic tests cover all three outcomes plus unavailable/invalid authority. |
 | CBR-013 | Permit issuance and execution start require durable security audit. | NOT IMPLEMENTED | The memory store has no audit port or durable issuance gate. |

--- a/src/cosh-ng/docs/design/acp-v1-phase-0-2/phase-1/capability-broker/acceptance_zh.md
+++ b/src/cosh-ng/docs/design/acp-v1-phase-0-2/phase-1/capability-broker/acceptance_zh.md
@@ -17,6 +17,22 @@ consume single-use permit。八个 targeted test 通过。
 OS executor、revocation、crash recovery、reconciliation、network API 与 ACP integration 均未实现。
 现有 CLI/Core/Shell mutation path 仍会绕过该切片。
 
+## Durable ledger storage 结果
+
+**整体结果为 VERIFIED DURABLE STORAGE SLICE；Broker integration 仍为 PARTIAL。** Checksummed
+SQLite v2 migration 现在会持久化 approval resolution、single-use permit、execution state 与 receipt、
+Runtime binding 和 fenced Run lease。Durable consume path replay authoritative Task event stream，
+要求准确的 current lease claim，并将 issued permit 和 planned execution 原子更新为 consumed/started。
+Recovery 将没有 receipt 的 started execution 标记为 `uncertain`，且不会 retry effect。基于 approval
+签发的 permit 不能超过 approval deadline，也不能扩大任何 approval binding。
+
+2026-08-13，`cargo +1.88.0 test --locked --package cosh-gateway storage --no-fail-fast`
+通过 28/28 个 targeted storage test。测试覆盖 stale lease、cross-Task Run、generation skip、扩大
+approval deadline、integer overflow、idempotency namespace、receipt corruption 与 atomic rollback。
+
+Process-local `CapabilityBroker` 尚未连接该 store，因此 existing bypass finding、immutable target
+resolution、required audit persistence、OS executor 与 reconciliation 仍待完成。
+
 ## 结果口径
 
 | 结果 | 含义 |
@@ -48,12 +64,12 @@ ACP 或 network API。
 | CBR-002 | Target 解析成 immutable authenticated identity。 | NOT IMPLEMENTED | 第一版只绑定 exact `TargetRef`；没有 resolver、boot/workspace/UID identity 或 attestation。 |
 | CBR-003 | Policy result、approval 与 permit 是不同类型。 | PARTIAL | `PolicyDecision`、`ApprovalRequest`、`CapabilityDecision` 与 `ExecutionPermit` 已分离；durable approval resolution/re-authorization 不存在。 |
 | CBR-004 | 每个 permitted effect 有一个 `ExecutionId`。 | PARTIAL | 每个 Broker-issued permit 都有一个 `ExecutionId`；bypass path 与 execution lifecycle 未集成。 |
-| CBR-005 | Permit 绑定 actor、Task、Run、target、operation digest、policy、fence、expiry 与一次使用。 | PARTIAL | Actor/Task/Run/Execution/exact target/完整 operation digest/policy/expiry/single-use binding 通过；immutable target 与 runtime/lease fence 尚缺。Canonicalization 与 hashing 仍依赖 trusted ingress。 |
-| CBR-006 | Target 在执行前立即校验并 consume permit。 | PARTIAL | `claim` atomically 校验并 consume，但没有 target adapter 或 durable store 在 effect 前调用。 |
-| CBR-007 | Approval 是 durable Task state 且不能扩大 authority。 | PARTIAL | Approval request 保留 request/Task/Run/expiry；没有 durable approval ledger、resolution 或 approval-bound issuance。Direct permit 的 `approval_id = None`。 |
+| CBR-005 | Permit 绑定 actor、Task、Run、target、operation digest、policy、fence、expiry 与一次使用。 | PARTIAL | Durable consume 校验准确 actor/Task/authoritative Run/Execution/target/digest/policy/expiry，以及 current lease generation 与 revision。Immutable target identity 和 production Broker wiring 尚缺。 |
+| CBR-006 | Target 在执行前立即校验并 consume permit。 | PARTIAL | Durable consume 与 execution start 在同一 transaction 中，但没有 OS target adapter 在 effect 前立即调用 ledger。 |
+| CBR-007 | Approval 是 durable Task state 且不能扩大 authority。 | PARTIAL | Durable approval resolution 与准确的 approval-bound issuance 已存在；approval ledger 尚未与 Task approval event 原子集成。仍支持 direct policy permit。 |
 | CBR-008 | Broker 不写 Task aggregate。 | PASS | Broker 不依赖 Task aggregate 或 storage，只返回 decision。 |
-| CBR-009 | 重复 execute 不能产生第二个 effect。 | PARTIAL | 八个 concurrent claim 只有一个成功，单进程 replay 失败；没有跨 restart 的 durable execution/effect ledger。 |
-| CBR-010 | Crash uncertainty 进入 typed reconciliation，不自动 retry。 | NOT IMPLEMENTED | 没有 execution lifecycle 或 reconciliation port。 |
+| CBR-009 | 重复 execute 不能产生第二个 effect。 | PARTIAL | Durable single-use consume 与 idempotent command receipt 可跨 restart；executor integration 仍需证明 `Replayed` outcome 不会重复 effect。 |
+| CBR-010 | Crash uncertainty 进入 typed reconciliation，不自动 retry。 | PARTIAL | Recovery 将所有没有 receipt 的 started execution 更新为 `uncertain` 且不 retry；typed reconciliation port 尚缺。 |
 | CBR-011 | Shell parsing 对 adversarial separator 与 metacharacter fail closed。 | PASS | 当前 parser/heuristic baseline 仍可复用；新 Broker 没有增加 Shell fallback。 |
 | CBR-012 | Typed policy 有 allow/deny/require-approval outcome。 | PASS | Neutral `PolicyPort` 与 deterministic test 覆盖三个 outcome，以及 unavailable/invalid authority。 |
 | CBR-013 | Permit issuance 与 execution start 要求 durable security audit。 | NOT IMPLEMENTED | Memory store 没有 audit port 或 durable issuance gate。 |

--- a/src/cosh-ng/docs/design/acp-v1-phase-0-2/phase-1/task-execution-plane/acceptance.md
+++ b/src/cosh-ng/docs/design/acp-v1-phase-0-2/phase-1/task-execution-plane/acceptance.md
@@ -27,6 +27,29 @@ Evidence recorded on 2026-08-13:
   idempotency replay/conflict, stale revisions, atomic Outbox rollback, schema/checksum rejection,
   private-path attacks, causation persistence, and event replay after a durable reopen.
 
+## Durable ledger slice
+
+**Overall: VERIFIED STORAGE SLICE; PHASE 1 EXIT NOT ACCEPTED.** The candidate now adds a
+checksummed v2 migration for durable approval, single-use permit, execution, runtime-binding, and
+Run-lease records. Every ledger mutation replays the authoritative Task event stream before using
+a Task/Run binding. Permit consumption and Runtime event acceptance require the exact current,
+unexpired lease generation and revision. Execution start consumes its permit atomically, while
+restart recovery marks an unreceipted started execution `uncertain` without retrying it.
+
+Evidence recorded on 2026-08-13:
+
+- `cargo +1.88.0 test --locked --package cosh-gateway storage --no-fail-fast` passed 28/28
+  targeted storage tests.
+- Adversarial fixtures cover a valid Run from another Task, stale lease revision, skipped Runtime
+  generation, permit expiry wider than approval, cross-plane idempotency-key reuse, SQLite integer
+  overflow, terminal receipt divergence, and rollback of rejected permit/execution mutations.
+- The task-command and ledger-command receipt tables enforce one actor-scoped idempotency
+  namespace. The v1 migration checksum remains unchanged and an existing v1 store upgrades to v2.
+
+This slice does not add `TaskCoordinator`, Outbox delivery workers, an executor, reconciliation,
+or a daemon API. Runtime sequence callbacks reject duplicate sequence numbers rather than replaying
+a stored callback result.
+
 ## Result vocabulary
 
 | Result | Meaning |
@@ -60,10 +83,10 @@ Evidence recorded on 2026-08-13:
 | TEP-003 | State reducer rejects every illegal transition. | PARTIAL | Reducer exists and critical transition tests pass; exhaustive state/event matrix is pending. |
 | TEP-004 | Event, snapshot, idempotency receipt, and outbox commit atomically. | PASS | `commit_task` uses `BEGIN IMMEDIATE`; a duplicate Delivery ID proves complete rollback. |
 | TEP-005 | Expected revision prevents stale writers. | PASS | Revision-conflict test leaves all Task tables empty. |
-| TEP-006 | Run lease has monotonic fencing and bounded renewal. | NOT IMPLEMENTED | Run lease absent. |
-| TEP-007 | Lease expiry never replays an unknown OS effect automatically. | NOT IMPLEMENTED | Reconciliation path absent. |
-| TEP-008 | Approval resolution is first-valid-terminal-wins. | PARTIAL | Reducer rejects resolved/non-pending approval IDs, but authorization and concurrent-decision fixture are pending. |
-| TEP-009 | Runtime and execution callbacks are idempotent and fenced. | NOT IMPLEMENTED | Ports absent. |
+| TEP-006 | Run lease has monotonic fencing and bounded renewal. | PASS | Lease acquire/renew/release requires exact owner, revision, generation, active Task/Run, and deadline; takeover increments generation. |
+| TEP-007 | Lease expiry never replays an unknown OS effect automatically. | PARTIAL | Started executions recover as `uncertain` and are not retried; executor reconciliation is absent. |
+| TEP-008 | Approval resolution is first-valid-terminal-wins. | PARTIAL | Durable pending-state CAS binds actor, revision, deadline, Task, and Run; a concurrent-decision fixture and Task-event integration remain. |
+| TEP-009 | Runtime and execution callbacks are idempotent and fenced. | PARTIAL | Ledger commands replay by actor/key/digest; permit start and Runtime sequence require the current lease. Runtime sequence replay and Runtime-port integration remain. |
 | TEP-010 | Event replay rebuilds an equivalent projection. | PASS | Durable-reopen recovery replays ordered envelopes and compares the exact snapshot. |
 | TEP-011 | Outbox restart is at-least-once with stable Delivery IDs. | PARTIAL | Stable rows persist, but dispatch leasing/reclaim/ack does not exist. |
 | TEP-012 | Task records exclude raw streams, secrets, and terminal buffers. | PARTIAL | Snapshot/event leaves are typed and bounded; Outbox payload, collection aggregate bounds, and secret classification remain. |

--- a/src/cosh-ng/docs/design/acp-v1-phase-0-2/phase-1/task-execution-plane/acceptance_zh.md
+++ b/src/cosh-ng/docs/design/acp-v1-phase-0-2/phase-1/task-execution-plane/acceptance_zh.md
@@ -26,6 +26,28 @@ Outbox delivery worker 或 execution reconciliation。
   replay/conflict、stale revision、Outbox atomic rollback、schema/checksum rejection、private-path attack、
   causation persistence，以及 durable reopen 后 event replay。
 
+## Durable ledger 切片
+
+**整体结果为 VERIFIED STORAGE SLICE；Phase 1 exit 尚未验收。** 当前 candidate 增加 checksummed
+v2 migration，持久化 approval、single-use permit、execution、runtime binding 与 Run lease。
+每次 ledger mutation 在使用 Task/Run binding 前都会 replay authoritative Task event stream。
+Permit consume 与 Runtime event acceptance 必须携带准确、当前且未过期的 lease generation 和
+revision。Execution start 与 permit consume 原子提交；restart recovery 将没有 receipt 的 started
+execution 标记为 `uncertain`，且不自动 retry。
+
+2026-08-13 记录的证据：
+
+- `cargo +1.88.0 test --locked --package cosh-gateway storage --no-fail-fast` 通过 28/28 个
+  targeted storage test。
+- Adversarial fixture 覆盖其他 Task 的有效 Run、stale lease revision、跳号 Runtime generation、
+  超过 approval 的 permit expiry、跨 plane idempotency key 复用、SQLite integer overflow、terminal
+  receipt divergence，以及 rejected permit/execution mutation 的完整 rollback。
+- Task command 与 ledger command receipt table 强制共享 actor-scoped idempotency namespace。
+  v1 migration checksum 保持不变，existing v1 store 可升级至 v2。
+
+该切片尚未增加 `TaskCoordinator`、Outbox delivery worker、executor、reconciliation 或 daemon API。
+Runtime sequence callback 对重复 sequence 采取 reject，而非 replay 已存 callback result。
+
 ## 结果口径
 
 | 结果 | 含义 |
@@ -59,10 +81,10 @@ Outbox delivery worker 或 execution reconciliation。
 | TEP-003 | State reducer 拒绝所有非法 transition。 | PARTIAL | Reducer 与关键 transition test 已通过；完整 state/event matrix 待补。 |
 | TEP-004 | Event、snapshot、idempotency receipt 与 outbox 原子 commit。 | PASS | `commit_task` 使用 `BEGIN IMMEDIATE`；重复 Delivery ID 证明完整 rollback。 |
 | TEP-005 | Expected revision 阻止 stale writer。 | PASS | Revision-conflict test 后所有 Task table 仍为空。 |
-| TEP-006 | Run lease 使用 monotonic fencing 与有界 renewal。 | NOT IMPLEMENTED | Run lease 不存在。 |
-| TEP-007 | Lease expiry 不会自动重放 unknown OS effect。 | NOT IMPLEMENTED | Reconciliation path 不存在。 |
-| TEP-008 | Approval resolution 使用 first-valid-terminal-wins。 | PARTIAL | Reducer 拒绝已 resolve/非 pending ID；authorization 与 concurrent-decision fixture 待补。 |
-| TEP-009 | Runtime 与 execution callback 幂等且带 fence。 | NOT IMPLEMENTED | Port 不存在。 |
+| TEP-006 | Run lease 使用 monotonic fencing 与有界 renewal。 | PASS | Lease acquire/renew/release 校验准确 owner、revision、generation、active Task/Run 与 deadline；takeover 增加 generation。 |
+| TEP-007 | Lease expiry 不会自动重放 unknown OS effect。 | PARTIAL | Started execution 在 recovery 时进入 `uncertain` 且不 retry；executor reconciliation 尚缺。 |
+| TEP-008 | Approval resolution 使用 first-valid-terminal-wins。 | PARTIAL | Durable pending-state CAS 绑定 actor、revision、deadline、Task 与 Run；concurrent-decision fixture 和 Task event integration 待补。 |
+| TEP-009 | Runtime 与 execution callback 幂等且带 fence。 | PARTIAL | Ledger command 按 actor/key/digest replay；permit start 与 Runtime sequence 要求 current lease。Runtime sequence replay 和 Runtime port integration 待补。 |
 | TEP-010 | Event replay 重建等价 projection。 | PASS | Durable reopen recovery replay ordered envelope，并比较完整 snapshot。 |
 | TEP-011 | Outbox restart 使用 at-least-once 与稳定 Delivery ID。 | PARTIAL | 稳定 row 已持久化，但 dispatch lease/reclaim/ack 不存在。 |
 | TEP-012 | Task record 排除 raw stream、secret 与 terminal buffer。 | PARTIAL | Snapshot/event leaf 已 typed/bounded；Outbox payload、collection aggregate bound 与 secret classification 待补。 |


### PR DESCRIPTION
## Why

Approval and execution governance cannot rely on process-local permits across
restarts or coordinator takeovers.

## What changed

- Persist approvals, permits, execution receipts, Runtime bindings, and leases.
- Fence execution and Runtime output by authoritative Task Run and active lease.
- Recover unreceipted started effects as uncertain without automatic retry.

## Related issue

no-issue: Stage 4 implementation from the audited ACP plan

## User / Agent impact

Gateway state now survives restart and rejects stale coordinator, cross-Task,
deadline-widening, and idempotency substitution attempts.

## Risk and compatibility

- [x] Privileged or security-sensitive behavior changed
- [x] Cross-component contract changed
- [x] Migration or rollback guidance is needed

The checksummed v2 migration preserves v1 data. Rolling back requires using a
pre-migration database backup; old binaries reject the newer schema.

## Validation

- 28 targeted storage tests on Rust 1.88.0
- adversarial stale-lease, cross-Task, overflow, receipt-corruption, and rollback cases
- clean detached-worktree library Clippy and rustdoc
- documentation lint, link, and diff checks

## Documentation and rollback

Updated bilingual Task-plane and Capability acceptance reports. Remaining gaps
include coordinator, executor, reconciliation, durable audit, and daemon wiring.