### PR TITLE
fix(cosh-ng): extend ACP startup deadline

### DIFF
--- a/src/cosh-ng/crates/cosh-gateway/src/runtime/acp_port.rs
+++ b/src/cosh-ng/crates/cosh-gateway/src/runtime/acp_port.rs
@@ -846,6 +846,7 @@ fn map_driver_error(error: AcpSessionDriverError) -> AgentRuntimePortError {
         | AcpSessionDriverError::CancellationPending
         | AcpSessionDriverError::ObservationBackpressure
         | AcpSessionDriverError::Cancelled => AgentRuntimePortError::Transport,
+        AcpSessionDriverError::InvalidDeadlineConfiguration => AgentRuntimePortError::Protocol,
     }
 }
 fn safe_error(

--- a/src/cosh-ng/crates/cosh-gateway/src/runtime/session_driver.rs
+++ b/src/cosh-ng/crates/cosh-gateway/src/runtime/session_driver.rs
@@ -18,6 +18,9 @@ const COMMAND_CAPACITY: usize = 8;
 const CONTROL_CAPACITY: usize = 1;
 const EVENT_CAPACITY: usize = 32;
 const MAX_TERMINAL_DETAIL_BYTES: usize = 4 * 1024;
+const DEFAULT_INITIALIZE_TIMEOUT: Duration = Duration::from_secs(60);
+const DEFAULT_COMMAND_TIMEOUT: Duration = Duration::from_secs(70);
+const SHUTDOWN_SETTLEMENT_MARGIN: Duration = Duration::from_secs(1);
 
 /// Deadlines and immutable launch inputs for one local ACP session.
 #[derive(Debug, Clone)]
@@ -53,11 +56,36 @@ impl AcpSessionDriverConfig {
             client,
             workspace: workspace.into(),
             additional_directories: Vec::new(),
-            initialize_timeout: Duration::from_secs(10),
+            initialize_timeout: DEFAULT_INITIALIZE_TIMEOUT,
             prompt_timeout: Duration::from_secs(30 * 60),
             shutdown_grace: Duration::from_secs(2),
-            command_timeout: Duration::from_secs(10),
+            // Keep the caller alive after the actor's protocol deadline so it
+            // receives the operation-specific result instead of a racing ack timeout.
+            command_timeout: DEFAULT_COMMAND_TIMEOUT,
         }
+    }
+
+    fn validate(&self) -> Result<(), AcpSessionDriverError> {
+        let initialize_minimum = self
+            .initialize_timeout
+            .checked_add(self.launch.stdin_write_timeout)
+            .and_then(|timeout| timeout.checked_add(CONTROL_POLL_INTERVAL))
+            .ok_or(AcpSessionDriverError::InvalidDeadlineConfiguration)?;
+        let shutdown_minimum = self
+            .shutdown_grace
+            // Supervisor settlement also reaps the child and drains the
+            // bounded stderr collector after the TERM grace expires.
+            .checked_add(SHUTDOWN_SETTLEMENT_MARGIN)
+            .ok_or(AcpSessionDriverError::InvalidDeadlineConfiguration)?;
+        if self.initialize_timeout.is_zero()
+            || self.command_timeout <= initialize_minimum
+            || self.command_timeout <= shutdown_minimum
+            || self.prompt_timeout.is_zero()
+            || self.shutdown_grace.is_zero()
+        {
+            return Err(AcpSessionDriverError::InvalidDeadlineConfiguration);
+        }
+        Ok(())
     }
 }
 
@@ -124,6 +152,9 @@ pub enum AcpSessionDriverError {
     /// Independent control cancelled a deadline-bound operation.
     #[error("ACP operation was cancelled")]
     Cancelled,
+    /// Configured deadlines cannot preserve actor-before-caller settlement.
+    #[error("ACP session deadline configuration is invalid")]
+    InvalidDeadlineConfiguration,
 }
 
 type Reply = SyncSender<Result<(), AcpSessionDriverError>>;
@@ -183,6 +214,7 @@ impl AcpSessionDriver {
     ///
     /// Returns bridge launch or actor thread creation failures.
     pub fn launch(config: AcpSessionDriverConfig) -> Result<Self, AcpSessionDriverError> {
+        config.validate()?;
         let bridge = AcpV1RuntimeBridge::launch(&config.launch, config.client.clone())?;
         let (command_sender, command_receiver) = mpsc::sync_channel(COMMAND_CAPACITY);
         let (cancel_sender, cancel_receiver) = mpsc::sync_channel(CONTROL_CAPACITY);

--- a/src/cosh-ng/crates/cosh-gateway/src/runtime/session_driver/tests.rs
+++ b/src/cosh-ng/crates/cosh-gateway/src/runtime/session_driver/tests.rs
@@ -6,10 +6,50 @@ use super::*;
 
 const FRAME_LIMIT: usize = 16 * 1024;
 
+#[test]
+fn default_command_deadline_outlives_adapter_startup() {
+    let config = AcpSessionDriverConfig::new(
+        RuntimeLaunchSpec::new("/bin/false", "/"),
+        AcpV1ClientConfig::new("cosh-ng", "0.15.0", FRAME_LIMIT),
+        "/",
+    );
+
+    assert_eq!(config.initialize_timeout, Duration::from_secs(60));
+    assert_eq!(config.command_timeout, Duration::from_secs(70));
+    assert!(config.validate().is_ok());
+}
+
+#[test]
+fn invalid_deadline_order_is_rejected_before_launch() {
+    let mut config = AcpSessionDriverConfig::new(
+        RuntimeLaunchSpec::new("/bin/false", "/"),
+        AcpV1ClientConfig::new("cosh-ng", "0.15.0", FRAME_LIMIT),
+        "/",
+    );
+    config.command_timeout = config.initialize_timeout;
+
+    assert!(matches!(
+        AcpSessionDriver::launch(config),
+        Err(AcpSessionDriverError::InvalidDeadlineConfiguration)
+    ));
+
+    let mut config = AcpSessionDriverConfig::new(
+        RuntimeLaunchSpec::new("/bin/false", "/"),
+        AcpV1ClientConfig::new("cosh-ng", "0.15.0", FRAME_LIMIT),
+        "/",
+    );
+    config.shutdown_grace = config.command_timeout - Duration::from_millis(500);
+    assert!(matches!(
+        AcpSessionDriver::launch(config),
+        Err(AcpSessionDriverError::InvalidDeadlineConfiguration)
+    ));
+}
+
 #[cfg(unix)]
 fn driver(script: &str, workspace: &tempfile::TempDir) -> AcpSessionDriver {
     let mut launch = RuntimeLaunchSpec::new("/bin/sh", workspace.path());
     launch.arguments = vec!["-c".into(), script.into()];
+    launch.stdin_write_timeout = Duration::from_millis(100);
     let mut config = AcpSessionDriverConfig::new(
         launch,
         AcpV1ClientConfig::new("cosh-ng", "0.15.0", FRAME_LIMIT),
@@ -20,6 +60,44 @@ fn driver(script: &str, workspace: &tempfile::TempDir) -> AcpSessionDriver {
     config.shutdown_grace = Duration::from_millis(50);
     config.command_timeout = Duration::from_secs(3);
     AcpSessionDriver::launch(config).unwrap()
+}
+
+#[cfg(unix)]
+#[test]
+fn default_startup_deadline_accepts_session_after_ten_seconds() {
+    let workspace = tempfile::tempdir().unwrap();
+    let script = r#"
+step=0
+while IFS= read -r line; do
+    step=$((step + 1))
+    case "$step" in
+        1) printf '%s\n' '{"jsonrpc":"2.0","id":"cosh-acp-1","result":{"protocolVersion":1,"agentCapabilities":{}}}' ;;
+        2)
+           sleep 11
+           printf '%s\n' '{"jsonrpc":"2.0","id":"cosh-acp-2","result":{"sessionId":"session-1"}}'
+           ;;
+    esac
+done
+"#;
+    let mut launch = RuntimeLaunchSpec::new("/bin/sh", workspace.path());
+    launch.arguments = vec!["-c".into(), script.into()];
+    let config = AcpSessionDriverConfig::new(
+        launch,
+        AcpV1ClientConfig::new("cosh-ng", "0.15.0", FRAME_LIMIT),
+        workspace.path(),
+    );
+    let driver = AcpSessionDriver::launch(config).unwrap();
+
+    driver.initialize().unwrap();
+    observation(&driver);
+    let started = Instant::now();
+    driver.open_session().unwrap();
+    assert!(started.elapsed() >= Duration::from_secs(10));
+    assert!(matches!(
+        observation(&driver),
+        AcpV1Observation::SessionOpened { .. }
+    ));
+    driver.shutdown().unwrap();
 }
 
 fn observation(driver: &AcpSessionDriver) -> AcpV1Observation {

--- a/src/cosh-ng/scripts/run-acp-conformance.sh
+++ b/src/cosh-ng/scripts/run-acp-conformance.sh
@@ -84,13 +84,29 @@ import sys
 
 scenario = sys.argv[1]
 events = []
+
+def terminal_safe(value):
+    normalized = " ".join(value.split())[:240]
+    return "".join(
+        character if character.isprintable() else f"\\u{ord(character):04x}"
+        for character in normalized
+    )
+
 for line in sys.stdin:
     record = json.loads(line)
     event = record.get("event")
     if not isinstance(event, str):
         raise SystemExit("COSH emitted a JSONL record without an event")
     if event == "error":
-        raise SystemExit("COSH emitted an error event")
+        code = record.get("code", "unknown_error")
+        message = record.get("message", "no diagnostic available")
+        if not isinstance(code, str):
+            code = "unknown_error"
+        if not isinstance(message, str):
+            message = "no diagnostic available"
+        raise SystemExit(
+            f"COSH error [{terminal_safe(code)}]: {terminal_safe(message)}"
+        )
     events.append(event)
 
 required = {

--- a/src/cosh-ng/tests/test-acp-adapters.sh
+++ b/src/cosh-ng/tests/test-acp-adapters.sh
@@ -100,6 +100,11 @@ gateway_stub="$temp_root/cosh-gateway"
 cat >"$gateway_stub" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
+if [[ "${FAKE_GATEWAY_ERROR:-0}" == 1 ]]; then
+  printf '%s\n' \
+    '{"event":"error","code":"bad\u001b[31m","message":"failed\u001b]8;;https://example.invalid\u0007link"}'
+  exit 12
+fi
 case "$1" in
   doctor)
     printf '%s\n' \
@@ -122,6 +127,16 @@ case "$1" in
 esac
 SH
 chmod 0700 "$gateway_stub"
+set +e
+diagnostic=$(FAKE_GATEWAY_ERROR=1 "$conformance" fake \
+  --gateway "$gateway_stub" --workspace "$workspace" 2>&1 >/dev/null)
+diagnostic_exit=$?
+set -e
+[[ "$diagnostic_exit" != 0 ]] || fail "control-bearing diagnostic unexpectedly passed"
+[[ "$diagnostic" == *'\u001b'* && "$diagnostic" == *'\u0007'* ]] || \
+  fail "control-bearing diagnostic was not escaped"
+[[ "$diagnostic" != *$'\033'* && "$diagnostic" != *$'\007'* ]] || \
+  fail "control-bearing diagnostic reached the terminal"
 expect_exit 2 "$conformance" real \
   --gateway "$gateway_stub" \
   --workspace "$workspace" \


### PR DESCRIPTION
## Why

Real `codex-acp` cold starts spent 7–10 seconds creating a session, racing the previous 10-second command acknowledgement deadline. The conformance harness then reduced the failure to a generic error with no safe diagnostic.

## What changed

Increase the ACP initialization budget to 60 seconds and the caller acknowledgement budget to 70 seconds. Validate startup and shutdown deadline ordering before launch, add a delayed-session regression, and emit bounded terminal-safe conformance errors.

## Related issue

no-issue: found during real Codex ACP conformance validation

## User / Agent impact

Cold Codex ACP startup no longer fails at the old 10-second boundary. Conformance failures now include a bounded, control-escaped COSH error code and message.

## Risk and compatibility

- [x] Public CLI, API, configuration, or documented behavior changed

The change only widens local startup deadlines and rejects internally inconsistent deadline configurations. ACP wire v1 behavior is unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --package cosh-gateway --all-targets --locked -- -D warnings`
- `cargo test --locked --package cosh-gateway --no-fail-fast`
- `cargo doc --package cosh-gateway --no-deps --locked`
- `bash tests/test-acp-adapters.sh`
- Real `codex-acp` 1.2.0 doctor and prompt conformance

## Documentation and rollback

No documentation change is required for this runtime correction. Revert commit `23c880bd` to restore the prior deadlines and diagnostic behavior.